### PR TITLE
fix build on OS X

### DIFF
--- a/src/annoylib.cc
+++ b/src/annoylib.cc
@@ -12,6 +12,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+#include "Python.h"
 #include <stdio.h>
 #include <string>
 #include <boost/python.hpp>


### PR DESCRIPTION
Build on OS X 10.7.5 fails with errors like

```
/usr/include/c++/4.2.1/bits/localefwd.h:58:34: error: macro "isspace" passed 2 arguments, but takes just 1
/usr/include/c++/4.2.1/bits/localefwd.h:70:34: error: macro "isupper" passed 2 arguments, but takes just 1
/usr/include/c++/4.2.1/bits/localefwd.h:74:34: error: macro "islower" passed 2 arguments, but takes just 1
/usr/include/c++/4.2.1/bits/localefwd.h:78:34: error: macro "isalpha" passed 2 arguments, but takes just 1
/usr/include/c++/4.2.1/bits/localefwd.h:94:34: error: macro "isalnum" passed 2 arguments, but takes just 1
/usr/include/c++/4.2.1/bits/localefwd.h:102:34: error: macro "toupper" passed 2 arguments, but takes just 1
/usr/include/c++/4.2.1/bits/localefwd.h:106:34: error: macro "tolower" passed 2 arguments, but takes just 1
```

Adding a Python.h header explicitly fixes this (got the idea from http://bugs.python.org/issue10910).
