### PR TITLE
FIX various python 3 compat fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ ____________
 
   u = AnnoyIndex(f)
   u.load('test.tree') # super fast, will just mmap the file
-  print u.get_nns_by_item(0, 1000) # will find the 1000 nearest neighbors
+  print(u.get_nns_by_item(0, 1000)) # will find the 1000 nearest neighbors
 
 
 Right now it only accepts integers as identifiers for items. Note that it will allocate memory for max(id)+1 items because it generally assumes you will have items 0 … n.

--- a/annoy/__init__.py
+++ b/annoy/__init__.py
@@ -12,7 +12,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from annoylib import *
+from .annoylib import *
 
 def AnnoyIndex(f, metric='angular'):
     if metric == 'angular':

--- a/examples/mmap_test.py
+++ b/examples/mmap_test.py
@@ -10,5 +10,5 @@ a.save('test.tree')
 b = AnnoyIndex(3)
 b.load('test.tree')
 
-print b.get_nns_by_item(0, 100)
-print b.get_nns_by_vector([1.0, 0.5, 0.5], 100)
+print(b.get_nns_by_item(0, 100))
+print(b.get_nns_by_vector([1.0, 0.5, 0.5], 100))

--- a/examples/precision_test.py
+++ b/examples/precision_test.py
@@ -1,5 +1,13 @@
+from __future__ import print_function
 import random, time
 from annoy import AnnoyIndex
+
+try:
+    xrange
+except NameError:
+    # Python 3 compat
+    xrange = range
+
 
 def precision(f=40, n=1000000):
     t = AnnoyIndex(f)
@@ -20,7 +28,7 @@ def precision(f=40, n=1000000):
 
     for i in xrange(prec_n):
         j = random.randrange(0, n)
-        print 'finding nbs for', j
+        print('finding nbs for', j)
         
         closest = set(t.get_nns_by_item(j, n)[:k])
         for limit in limits:
@@ -34,7 +42,9 @@ def precision(f=40, n=1000000):
             time_sum[limit] = time_sum.get(limit, 0.0) + T
 
         for limit in limits:
-            print 'limit: %-9d precision: %6.2f%% avg time: %.6fs' % (limit, 100.0 * prec_sum[limit] / (i + 1), time_sum[limit] / (i + 1))
+            print('limit: %-9d precision: %6.2f%% avg time: %.6fs'
+                  % (limit, 100.0 * prec_sum[limit] / (i + 1),
+                     time_sum[limit] / (i + 1)))
 
 if __name__ == '__main__':
     precision()

--- a/examples/simple_test.py
+++ b/examples/simple_test.py
@@ -6,5 +6,5 @@ a.add_item(1, [0, 1, 0])
 a.add_item(2, [0, 0, 1])
 a.build(-1)
 
-print a.get_nns_by_item(0, 100)
-print a.get_nns_by_vector([1.0, 0.5, 0.5], 100)
+print(a.get_nns_by_item(0, 100))
+print(a.get_nns_by_vector([1.0, 0.5, 0.5], 100))

--- a/test/_annoy_test.py
+++ b/test/_annoy_test.py
@@ -19,6 +19,12 @@ import unittest
 import random
 from annoy import AnnoyIndex
 
+try:
+    xrange
+except NameError:
+    # Python 3 compat
+    xrange = range
+
 
 class AngularIndexTest(unittest.TestCase):
     def test_get_nns_by_vector(self):

--- a/test/test.py
+++ b/test/test.py
@@ -34,8 +34,8 @@ class run(unittest.TestProgram):
 
     def usageExit(self, msg=None):
         if msg:
-            print msg
-        print self.USAGE % self.__dict__
+            print(msg)
+        print(self.USAGE % self.__dict__)
         sys.exit(-2)
 
     def runTests(self):


### PR DESCRIPTION
Here are some fixes to make annoy run under Python 3 (note `libboost_python.so` needs to be build against the matching version of Python).

I have the following test failures though:

```
======================================================================
FAIL: test_get_nns_by_item (_annoy_test.AngularIndexTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/code/annoy/test/_annoy_test.py", line 48, in test_get_nns_by_item
    self.assertEqual(i.get_nns_by_item(0, 3), [0,1,2])
AssertionError: Lists differ: [0, 1] != [0, 1, 2]

Second list contains 1 additional elements.
First extra element 2:
2

- [0, 1]
+ [0, 1, 2]
?      +++


======================================================================
FAIL: test_get_nns_by_vector (_annoy_test.AngularIndexTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/code/annoy/test/_annoy_test.py", line 38, in test_get_nns_by_vector
    self.assertEqual(i.get_nns_by_vector([3,2,1], 3), [0,1,2])
AssertionError: Lists differ: [0, 1] != [0, 1, 2]

Second list contains 1 additional elements.
First extra element 2:
2

- [0, 1]
+ [0, 1, 2]
?      +++


======================================================================
FAIL: test_large_index (_annoy_test.AngularIndexTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/code/annoy/test/_annoy_test.py", line 100, in test_large_index
    self.assertEqual(i.get_nns_by_item(j, 2), [j, j+1])
AssertionError: Lists differ: [39, 38] != [144, 145]

First differing element 0:
39
144

- [39, 38]
+ [144, 145]

======================================================================
FAIL: test_large_index (_annoy_test.EuclideanIndexTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/code/annoy/test/_annoy_test.py", line 136, in test_large_index
    self.assertEqual(i.get_nns_by_item(j, 2), [j, j+1])
AssertionError: Lists differ: [27, 26] != [154, 155]

First differing element 0:
27
154

- [27, 26]
+ [154, 155]

======================================================================
FAIL: test_precision_10 (_annoy_test.EuclideanIndexTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/code/annoy/test/_annoy_test.py", line 161, in test_precision_10
    self.assertEqual(self.precision(10), 1.0)
AssertionError: 0.3 != 1.0

======================================================================
FAIL: test_precision_100 (_annoy_test.EuclideanIndexTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/code/annoy/test/_annoy_test.py", line 164, in test_precision_100
    self.assertGreaterEqual(self.precision(100), 0.99)
AssertionError: 0.83 not greater than or equal to 0.99

======================================================================
FAIL: test_precision_1000 (_annoy_test.EuclideanIndexTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/code/annoy/test/_annoy_test.py", line 167, in test_precision_1000
    self.assertGreaterEqual(self.precision(1000), 0.99)
AssertionError: 0.892 not greater than or equal to 0.99

----------------------------------------------------------------------
Ran 15 tests in 3.827s
```

I will try to rebuilt everything under Python 2.7 to check if I reproduce those failures there. It might not be related to the python version but to the gcc / libboost version. In my case I built it with:
- gcc / g++ 4.9.1
- libboost-python-dev                   1.55.0.2

under Debian Jessie.
