### PR TITLE
Replacing an explicit loop with std::copy to solve #3 and #13

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -392,8 +392,9 @@ protected:
     m->n_descendants = indices.size();
 
     if (indices.size() <= (size_t)_K) {
-      for (size_t i = 0; i < indices.size(); i++)
-        m->children[i] = indices[i];
+      // Using std::copy instead of a loop seems to resolve issues #3 and #13,
+      // probably because gcc 4.8 goes overboard with optimizations.
+      copy(indices.begin(), indices.end(), m->children);
       return item;
     }
 


### PR DESCRIPTION
This seems to do the trick when I'm running it on an EC2 instance. Seems like GCC 4.8 goes too far optimizing redundant loops and removes the loop (that's the only explanation I can think of).
