### PR TITLE
inremental add_item_to_index and load_memory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,11 +31,13 @@ Summary of features
 -------------------
 
 * Euclidean distance (squared) or cosine similarity (using the squared distance of the normalized vectors)
-* Works better if you don't have too many dimensions (like <100) but seems to perform surprisingly well even up to 1,000 dimensions
-* Small memory usage
+* Works better if you don't have too many dimensions (like <100) but seems to perform surprisingly well even up to 1,000 dimensions; works pretty fine with dimension up to 4000. 
+* Small memory usage in searching because memory map is used
 * Lets you share memory between multiple processes
-* Index creation is separate from lookup (in particular you can not add more items once the tree has been created)
+* Index creation is separate from lookup
 * Native Python support
+* Support dynamic index add. ( will support delete and update in the future)
+* Each sample contains a field label for filtering results -- i.e. search query can contain a list of target labels to search for.
 
 Code example
 ____________
@@ -48,7 +50,7 @@ ____________
       v = []
       for z in xrange(f):
           v.append(random.gauss(0, 1))
-      t.add_item(i, v, [1])
+      t.add_item(i, v, 1)  # add items with label 1
 
   t.build(10) # 10 trees
   t.save('test.tree')
@@ -57,7 +59,7 @@ ____________
 
   u = AnnoyIndex(f)
   u.load('test.tree') # super fast, will just mmap the file
-  print(u.get_nns_by_item(0, 1000, [1], 10000)) # will find the 1000 nearest neighbors
+  print(u.get_nns_by_item(0, 1000, [1,2], 10000)) # will find the 1000 nearest neighbors, accurate search from top 10000 candidates with label 1 or 2
 
 
 Right now it only accepts integers as identifiers for items. Note that it will allocate memory for max(id)+1 items because it assumes your items are numbered 0 … n-1. If you need other id's, you will have to keep track of a map yourself.

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,15 @@ Annoy
 What is this?
 -------------
 
+.. image:: https://img.shields.io/travis/spotify/annoy/master.svg?style=flat
+    :target: https://travis-ci.org/spotify/annoy
+
+.. image:: https://img.shields.io/pypi/dm/annoy.svg?style=flat
+   :target: https://pypi.python.org/pypi/annoy
+
+.. image:: https://img.shields.io/pypi/l/annoy.svg?style=flat
+   :target: https://pypi.python.org/pypi/annoy
+
 Annoy (`Approximate Nearest Neighbors <http://en.wikipedia.org/wiki/Nearest_neighbor_search#Approximate_nearest_neighbor>`__ Something Something) is a C++ library with Python bindings to search for points in space that are close to a given query point. It also creates large read-only file-based data structures that are mmapped into memory so that many processes may share the same data.
 
 There's a couple of other libraries to do approximate nearest neighbor search, including `FLANN <https://github.com/mariusmuja/flann>`__, etc. Other libraries may be both faster and more accurate, but there are one major difference that sets Annoy apart: it has the ability to **use static files as indexes**. In particular, this means you can **share index across processes**. Annoy also decouples creating indexes from loading them, so you can pass around indexes as files and map them into memory quickly. Another nice thing of Annoy is that it tries to minimize memory footprint so the indexes are quite small.

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ More info
 ---------
 
 * `Dirk Eddelbuettel <http://dirk.eddelbuettel.com/>`__ provides an `R version of Annoy <http://dirk.eddelbuettel.com/code/rcpp.annoy.html>`__.
-* `Andy Sloane <http://www.a1k0n.net/>`__ provides a `Java version of Annoy <http://dirk.eddelbuettel.com/code/rcpp.annoy.html>`__ although currently limited to cosine and read-only.
+* `Andy Sloane <http://www.a1k0n.net/>`__ provides a `Java version of Annoy <https://github.com/spotify/annoy-java>`__ although currently limited to cosine and read-only.
 
 For some interesting stats, check out Radim Řehůřek's great blog posts comparing Annoy to a couple of other similar Python libraries:
 

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ ____________
       v = []
       for z in xrange(f):
           v.append(random.gauss(0, 1))
-      t.add_item(i, v)
+      t.add_item(i, v, [1])
 
   t.build(10) # 10 trees
   t.save('test.tree')
@@ -57,7 +57,7 @@ ____________
 
   u = AnnoyIndex(f)
   u.load('test.tree') # super fast, will just mmap the file
-  print(u.get_nns_by_item(0, 1000)) # will find the 1000 nearest neighbors
+  print(u.get_nns_by_item(0, 1000, [1], 10000)) # will find the 1000 nearest neighbors
 
 
 Right now it only accepts integers as identifiers for items. Note that it will allocate memory for max(id)+1 items because it assumes your items are numbered 0 … n-1. If you need other id's, you will have to keep track of a map yourself.

--- a/examples/precision_test.py
+++ b/examples/precision_test.py
@@ -9,13 +9,13 @@ except NameError:
     xrange = range
 
 
-def precision(f=40, n=1000000):
+def precision(f=40, n=1000):
     t = AnnoyIndex(f)
     for i in xrange(n):
         v = []
         for z in xrange(f):
             v.append(random.gauss(0, 1))
-        t.add_item(i, v)
+        t.add_item(i, v, 1)
 
     t.build(2 * f)
     t.save('test.tree')
@@ -30,10 +30,10 @@ def precision(f=40, n=1000000):
         j = random.randrange(0, n)
         print('finding nbs for', j)
         
-        closest = set(t.get_nns_by_item(j, n)[:k])
+        closest = set(t.get_nns_by_item(j, n, [1], j* 100)[:k])
         for limit in limits:
             t0 = time.time()
-            toplist = t.get_nns_by_item(j, limit)
+            toplist = t.get_nns_by_item(j, limit, [1], j* 100)
             T = time.time() - t0
             
             found = len(closest.intersection(toplist))

--- a/examples/simple_test.py
+++ b/examples/simple_test.py
@@ -6,5 +6,5 @@ a.add_item(1, [0, 1, 0], 1)
 a.add_item(2, [0, 0, 1], 1)
 a.build(-1)
 
-print(a.get_nns_by_item(1, 100, [1], 10))
-print(a.get_nns_by_vector([1.0, 0.5, 0.5], 100, [1], 1000))
+print(a.get_nns_by_item(1, 100, [2], 10))
+print(a.get_nns_by_vector([1.0, 0.5, 0.5], 100, [], 1000))

--- a/examples/simple_test.py
+++ b/examples/simple_test.py
@@ -1,10 +1,10 @@
 from annoy import AnnoyIndex
 
 a = AnnoyIndex(3)
-a.add_item(0, [1, 0, 0])
-a.add_item(1, [0, 1, 0])
-a.add_item(2, [0, 0, 1])
+a.add_item(0, [1, 0, 0], 1)
+a.add_item(1, [0, 1, 0], 1)
+a.add_item(2, [0, 0, 1], 1)
 a.build(-1)
 
-print(a.get_nns_by_item(0, 100))
-print(a.get_nns_by_vector([1.0, 0.5, 0.5], 100))
+print(a.get_nns_by_item(1, 100, [1], 10))
+print(a.get_nns_by_vector([1.0, 0.5, 0.5], 100, [1], 1000))

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -273,6 +273,18 @@ public:
       free(_nodes);
     }
   }
+  //update the label of an item
+  S update_label(S item_id, S label) {
+    if (item_id >= _n_items || item_id < 0) {
+      return -1;
+    }
+    typename Distance::node* m = _get(item_id);  
+    if (m != NULL) {
+       m->label = label;
+    }
+    return 1;
+  }
+
   //add one item to existing built index, return the item id 
   S add_item_to_index(const T* w, S label) {
     S item = _n_items;

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -644,25 +644,6 @@ protected:
           
   }
 
-  void _get_nns(const T* v, S i, vector<S>* result, S limit) {
-    const typename Distance::node* n = _get(i);
-
-    if (n->n_descendants == 0) {
-      // unknown item, nothing to do...
-    } else if (n->n_descendants == 1) {
-      result->push_back(i);
-    } else if (n->n_descendants <= _K) {
-      const S* dst = n->children;
-      result->insert(result->end(), n->children, &dst[n->descendants]);
-    } else {
-      bool side = Distance::side(n, v, _f, &_random);
-
-      _get_nns(v, n->children[side], result, limit);
-      if (result->size() < (size_t)limit)
-        _get_nns(v, n->children[!side], result, limit);
-    }
-  }
-
   void _get_all_nns(const T* v, size_t n, vector<S>* result, vector<S>& label_set, size_t tn) {
     std::priority_queue<pair<T, S> > q;
     std::map<S, bool> r; // retrieved items map

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -668,7 +668,7 @@ protected:
       if (nd->n_descendants == 1) {
         if (r.find(i) == r.end())
         {
-            if (cset.find(nd->label) != cset.end()) {
+            if (cset.size() == 0 || cset.find(nd->label) != cset.end()) {
                nns_dist.push_back(make_pair(Distance::distance(v, _get(i)->v, _f), i));
                r.insert(make_pair(i, true));
             }
@@ -678,7 +678,7 @@ protected:
         for (size_t kk = 0; kk < nd->n_descendants; kk ++ ) {
           int w = nd->children[kk];
           if (r.find(w) == r.end()) {
-            if (cset.find(_get(w)->label) != cset.end()) {
+            if (cset.size() == 0 || cset.find(_get(w)->label) != cset.end()) {
               nns_dist.push_back(make_pair(Distance::distance(v, _get(w)->v, _f), w));
               r.insert(make_pair(w, true));
             }

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -51,14 +51,54 @@ public:
     vector<S> w(c_size);
     for (int z = 0; z < c_size; z++)
       w[z] = python::extract<S>(c[z]);
-    vector<S> result;
+    vector<pair<T, S> > result;
     this->get_nns_by_item(item, n, &result, w, tn);
     python::list l;
-    for (size_t i = 0; i < result.size(); i++)
-      l.append(result[i]);
+    for (size_t i = 0; i < result.size(); i++) {
+      python::list t;
+      t.append(result[i].first);
+      t.append(result[i].second);
+      l.append(t);
+    }
     return l;
   }
 
+  python::list get_nns_group_by_item_py(S item, size_t n, python::list c, size_t tn, T dist_threshold) {
+    size_t c_size = boost::python::len(c);
+    vector<S> cs(c_size);
+    vector<vector<S> > group_result;
+    this->get_nns_group_by_item(item, n, &group_result, cs, tn, dist_threshold);
+    python::list l;
+    for (size_t i = 0; i < group_result.size(); i++) {
+      python::list a;
+      for (size_t j = 0; j < group_result[i].size(); j ++ ) { 
+        a.append(group_result[i][j]); 
+      }
+      l.append(a);
+    }
+    return l;
+  }
+
+  python::list get_nns_group_by_vector_py(python::list v, size_t n, python::list c, size_t tn, T dist_threshold) {
+    size_t c_size = boost::python::len(c);
+    vector<S> cs(c_size);
+    for (int z = 0; z < c_size; z++)
+      cs[z] = python::extract<S>(c[z]);
+    vector<T> w(this->_f);
+    for (int z = 0; z < this->_f; z++)
+      w[z] = python::extract<T>(v[z]);
+    vector<vector<S> > group_result;
+    this->get_nns_group_by_vector(&w[0], n, &group_result, cs, tn, dist_threshold);
+    python::list l;
+    for (size_t i = 0; i < group_result.size(); i++) {
+      python::list a;
+      for (size_t j = 0; j < group_result[i].size(); j ++ ) { 
+        a.append(group_result[i][j]); 
+      }
+      l.append(a);
+    }
+    return l;
+  }
   python::list get_nns_by_vector_py(python::list v, size_t n, python::list c, size_t tn) {
     size_t c_size = boost::python::len(c);
     vector<S> cs(c_size);
@@ -67,11 +107,15 @@ public:
     vector<T> w(this->_f);
     for (int z = 0; z < this->_f; z++)
       w[z] = python::extract<T>(v[z]);
-    vector<S> result;
+    vector<pair<T, S> > result;
     this->get_nns_by_vector(&w[0], n, &result, cs, tn);
     python::list l;
-    for (size_t i = 0; i < result.size(); i++)
-      l.append(result[i]);
+    for (size_t i = 0; i < result.size(); i++) {
+      python::list t;
+      t.append(result[i].first);
+      t.append(result[i].second);
+      l.append(t);
+    }
     return l;
   }
 
@@ -110,10 +154,13 @@ void expose_methods(python::class_<C> c) {
     .def("unload",            &C::unload)
     .def("get_distance",      &C::get_distance)
     .def("get_nns_by_item",   &C::get_nns_by_item_py)
+    .def("get_nns_group_by_item",     &C::get_nns_group_by_item_py)
+    .def("get_nns_group_by_vector",     &C::get_nns_group_by_vector_py)
     .def("get_nns_by_vector", &C::get_nns_by_vector_py)
     .def("get_item_vector",   &C::get_item_vector_py)
     .def("get_n_items",       &C::get_n_items)
     .def("verbose",           &C::verbose);
+
 }
 
 BOOST_PYTHON_MODULE(annoylib)

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -53,8 +53,8 @@ public:
     return this->update_label(item, label);
   }
 
-  void get_all_groups_py(T dist_threshold) {
-    this->get_all_groups(dist_threshold);
+  void get_all_groups_py(T dist_threshold, S search_tree_count) {
+    this->get_all_groups(dist_threshold, search_tree_count);
     return;
   }
 

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -46,8 +46,11 @@ public:
     vector<T> w;
     for (int z = 0; z < this->_f; z++)
       w.push_back(python::extract<T>(v[z]));
+    return this->add_item_to_index(&w[0], label);
+  }
 
-   return this->add_item_to_index(&w[0], label);
+  S update_label_py(S item, size_t label) {
+    return this->update_label(item, label);
   }
 
   void get_all_groups_py(T dist_threshold) {
@@ -157,6 +160,7 @@ void expose_methods(python::class_<C> c) {
   c.def("add_item",          &C::add_item_py)
     .def("add_item_to_index", &C::add_item_to_index_py)
     .def("set_item_size",     &C::set_item_size)
+    .def("update_label",	&C::update_label_py)
     .def("build",             &C::build)
     .def("save",              &C::save_py)
     .def("load",              &C::load_py)

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -39,6 +39,9 @@ public:
 
     this->add_item(item, &w[0], label);
   }
+  S set_item_size_py(size_t size) { 
+    return this->set_item_size(size); 
+  }
   S add_item_to_index_py(const python::list& v, size_t label) {
     vector<T> w;
     for (int z = 0; z < this->_f; z++)
@@ -46,6 +49,12 @@ public:
 
    return this->add_item_to_index(&w[0], label);
   }
+
+  void get_all_groups_py(T dist_threshold) {
+    this->get_all_groups(dist_threshold);
+    return;
+  }
+
   python::list get_nns_by_item_py(S item, size_t n, python::list c, size_t tn) {
     size_t c_size = boost::python::len(c);
     vector<S> w(c_size);
@@ -147,12 +156,14 @@ template<typename C>
 void expose_methods(python::class_<C> c) {
   c.def("add_item",          &C::add_item_py)
     .def("add_item_to_index", &C::add_item_to_index_py)
+    .def("set_item_size",     &C::set_item_size)
     .def("build",             &C::build)
     .def("save",              &C::save_py)
     .def("load",              &C::load_py)
     .def("load_memory",       &C::load_memory_py)
     .def("unload",            &C::unload)
     .def("get_distance",      &C::get_distance)
+    .def("get_all_groups",    &C::get_all_groups_py)
     .def("get_nns_by_item",   &C::get_nns_by_item_py)
     .def("get_nns_group_by_item",     &C::get_nns_group_by_item_py)
     .def("get_nns_group_by_vector",     &C::get_nns_group_by_vector_py)

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -39,6 +39,13 @@ public:
 
     this->add_item(item, &w[0]);
   }
+  S add_item_to_index_py(const python::list& v) {
+    vector<T> w;
+    for (int z = 0; z < this->_f; z++)
+      w.push_back(python::extract<T>(v[z]));
+
+   return this->add_item_to_index(&w[0]);
+  }
   python::list get_nns_by_item_py(S item, size_t n) {
     vector<S> result;
     this->get_nns_by_item(item, n, &result);
@@ -75,14 +82,20 @@ public:
     if (!this->load(filename))
       throw ErrnoException();
   }
+  void load_memory_py(const string& filename) {
+    if (!this->load_memory(filename))
+      throw ErrnoException();
+  }
 };
 
 template<typename C>
 void expose_methods(python::class_<C> c) {
   c.def("add_item",          &C::add_item_py)
+    .def("add_item_to_index", &C::add_item_to_index_py)
     .def("build",             &C::build)
     .def("save",              &C::save_py)
     .def("load",              &C::load_py)
+    .def("load_memory",       &C::load_memory_py)
     .def("unload",            &C::unload)
     .def("get_distance",      &C::get_distance)
     .def("get_nns_by_item",   &C::get_nns_by_item_py)


### PR DESCRIPTION


the main changes:


1. to avoid all the mass around mmap, i added a function, load_memory(), to load everything into the memory. The following operations would work on memory to avoid complications on mmap. Believe me I had tried to use stuffs like mremap and struggled a bit and feel we better off to load it memory and save to a different filename. 

2. the function add_item_to_index(T* w) would add a new item to existing index.  The newly added item will be saved at the space right after the last existing item. Before doing so, of course, I have to move the nodes at the position to the end of the array -- again, i have to remove the roots at the end of array when I load the file. 

3. also, in order to be able to move nodes around, i have to add an additional field "parent" to save a node's parents. 

4. i will wrap a python service ( probably based on tornado) to this index. so when there is a request to add an item, the service will load the index in memory, add the item, and save the updated index to a different file. the service keep a point to "current" index and "working" index. when serving traffic, the request still read from mmap. 
