### PR TITLE
Boost dependences is removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.egg-info/
+*.egg/
 *.so
 build/
 dist/
 MANIFEST
 *.py[cod]
+*.idea

--- a/annoy/__init__.py
+++ b/annoy/__init__.py
@@ -15,8 +15,8 @@
 from .annoylib import *
 
 def AnnoyIndex(f, metric='angular'):
-    if metric == 'angular':
-        return AnnoyIndexAngular(f)
-    elif metric == 'euclidean':
-        return AnnoyIndexEuclidean(f)
+    """
+        :param metric: 'angular' or 'euclidean'
+    """
+    return Annoy(f, metric)
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,13 @@ setup(name='annoy',
       version='1.0.5',
       description='Approximate Nearest Neighbors in C++/Python optimized for memory usage and loading/saving to disk.',
       packages=['annoy'],
-      ext_modules=[Extension('annoy.annoylib', ['src/annoymodule.cc'], libraries=['boost_python'])],
+      ext_modules=[
+        Extension(
+            'annoy.annoylib', ['src/annoymodule.cc'],
+            depends=['src/annoylib.h'],
+            extra_compile_args=['-std=c++11'],
+        )
+      ],
       long_description=long_description,
       author='Erik Bernhardsson',
       author_email='erikbern@spotify.com',

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -77,7 +77,7 @@ struct Randomness {
     return _var_ber(generator); 
   }
   inline T uniform(T min, T max) {
-    return _var_uni(generator) + min + max;
+    return _var_uni(generator) * (max - min) + min;
   }
 };
 

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -34,13 +34,10 @@
 #include <string.h>
 #include <math.h>
 #include <vector>
+#include <algorithm>
 #include <queue>
 #include <limits>
-#include <boost/version.hpp>
-#include <boost/random.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/bernoulli_distribution.hpp>
+#include <random>
 
 // This allows others to supply their own logger / error printer without
 // requiring Annoy to import their headers. See RcppAnnoy for a use case.
@@ -60,40 +57,27 @@ using std::string;
 using std::pair;
 using std::numeric_limits;
 using std::make_pair;
-using boost::variate_generator;
-using boost::uniform_01;
-
-#if BOOST_VERSION > 1004400
-#define BOOST_RANDOM boost::random
-#else
-#define BOOST_RANDOM boost
-#endif
 
 template<typename T>
 struct Randomness {
   // Just a dummy class to avoid code repetition.
   // Owned by the AnnoyIndex, passed around to the distance metrics
 
-  BOOST_RANDOM::mt19937 _rng;
-  BOOST_RANDOM::normal_distribution<T> _nd;
-  variate_generator<BOOST_RANDOM::mt19937&, 
-                    BOOST_RANDOM::normal_distribution<T> > _var_nor;
-  uniform_01<T> _ud;
-  variate_generator<BOOST_RANDOM::mt19937&, 
-                    uniform_01<T> > _var_uni;
-  BOOST_RANDOM::bernoulli_distribution<T> _bd;
-  variate_generator<BOOST_RANDOM::mt19937&, 
-                    BOOST_RANDOM::bernoulli_distribution<T> > _var_ber;
+  std::mt19937 generator;
+  std::normal_distribution<T> _var_nor;
+  std::bernoulli_distribution _var_ber;
+  std::uniform_real_distribution<T> _var_uni;
+  Randomness() : _var_nor(0,1), _var_ber(0.5), _var_uni() {};
 
-  Randomness() : _rng(), _nd(), _var_nor(_rng, _nd), _ud(), _var_uni(_rng, _ud), _bd(), _var_ber(_rng, _bd) {}
   inline T gaussian() {
-    return _var_nor();
+    return _var_nor(generator);
   }
+
   inline int flip() {
-    return _var_ber();
+    return _var_ber(generator); 
   }
   inline T uniform(T min, T max) {
-    return _var_uni() * (max - min) + min;
+    return _var_uni(generator) + min + max;
   }
 };
 
@@ -306,8 +290,8 @@ public:
     if (_verbose) showUpdate("has %d nodes\n", _n_nodes);
   }
 
-  bool save(const string& filename) {
-    FILE *f = fopen(filename.c_str(), "w");
+  bool save(const char* filename) {
+    FILE *f = fopen(filename, "w");
     if (f == NULL)
       return false;
 
@@ -340,8 +324,8 @@ public:
     if (_verbose) showUpdate("unloaded\n");
   }
 
-  bool load(const string& filename) {
-    int fd = open(filename.c_str(), O_RDONLY, (mode_t)0400);
+  bool load(const char* filename) {
+    int fd = open(filename, O_RDONLY, (mode_t)0400);
     if (fd == -1)
       return false;
     off_t size = lseek(fd, 0, SEEK_END);
@@ -530,8 +514,8 @@ protected:
       if (nd->n_descendants == 1) {
         nns.push_back(i);
       } else if (nd->n_descendants <= _K) {
-	const S* dst = nd->children;
-	nns.insert(nns.end(), nd->children, &dst[nd->n_descendants]);
+        const S* dst = nd->children;
+        nns.insert(nns.end(), nd->children, &dst[nd->n_descendants]);
       } else {
         T margin = Distance::margin(nd, v, _f);
         q.push(make_pair(+margin, nd->children[1]));
@@ -539,7 +523,7 @@ protected:
       }
     }
 
-    sort(nns.begin(), nns.end());
+    std::sort(nns.begin(), nns.end());
     vector<pair<T, S> > nns_dist;
     S last = -1;
     for (size_t i = 0; i < nns.size(); i++) {
@@ -558,3 +542,4 @@ protected:
 };
 
 #endif
+// vim: tabstop=2 shiftwidth=2

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -41,9 +41,9 @@ public:
 
   PyObject* get_nns_by_vector_py(PyObject* v, size_t n) {
     vector<T> w(this->_f);
-    for (int z = 0; z < PyList_Size(v); z++) {
+    for (int z = 0; z < PyList_Size(v) && z < this->_f; z++) {
         PyObject *pf = PyList_GetItem(v,z);
-        w.push_back(PyFloat_AsDouble(pf));
+        w[z] = PyFloat_AsDouble(pf);
     }
     vector<S> result;
     this->get_nns_by_vector(&w[0], n, &result);

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -439,44 +439,44 @@ static PyMethodDef AnnoyMethods[] = {
 
 static PyTypeObject PyAnnoyType = {
   PyObject_HEAD_INIT(NULL)
-  0,						 /*ob_size*/
-  "annoy.Annoy",			 /*tp_name*/
-  sizeof(py_annoy),			 /*tp_basicsize*/
-  0,						 /*tp_itemsize*/
+  0,                      /*ob_size*/
+  "annoy.Annoy",          /*tp_name*/
+  sizeof(py_annoy),       /*tp_basicsize*/
+  0,                      /*tp_itemsize*/
   (destructor)py_an_dealloc, /*tp_dealloc*/
-  0,						 /*tp_print*/
-  0,						 /*tp_getattr*/
-  0,						 /*tp_setattr*/
-  0,						 /*tp_compare*/
-  0,						 /*tp_repr*/
-  0,						 /*tp_as_number*/
-  0,						 /*tp_as_sequence*/
-  0,						 /*tp_as_mapping*/
-  0,						 /*tp_hash */
-  0,						 /*tp_call*/
-  0,						 /*tp_str*/
-  0,						 /*tp_getattro*/
-  0,						 /*tp_setattro*/
-  0,						 /*tp_as_buffer*/
+  0,                      /*tp_print*/
+  0,                      /*tp_getattr*/
+  0,                      /*tp_setattr*/
+  0,                      /*tp_compare*/
+  0,                      /*tp_repr*/
+  0,                      /*tp_as_number*/
+  0,                      /*tp_as_sequence*/
+  0,                      /*tp_as_mapping*/
+  0,                      /*tp_hash */
+  0,                      /*tp_call*/
+  0,                      /*tp_str*/
+  0,                      /*tp_getattro*/
+  0,                      /*tp_setattro*/
+  0,                      /*tp_as_buffer*/
   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
-  "annoy objects",			 /* tp_doc */
-  0,						 /* tp_traverse */
-  0,						 /* tp_clear */
-  0,						 /* tp_richcompare */
-  0,						 /* tp_weaklistoffset */
-  0,						 /* tp_iter */
-  0,						 /* tp_iternext */
-  AnnoyMethods,				 /* tp_methods */
-  py_annoy_members,			 /* tp_members */
-  0,						 /* tp_getset */
-  0,						 /* tp_base */
-  0,						 /* tp_dict */
-  0,						 /* tp_descr_get */
-  0,						 /* tp_descr_set */
-  0,						 /* tp_dictoffset */
-  (initproc)py_an_init,		 /* tp_init */
-  0,						 /* tp_alloc */
-  py_an_new,				 /* tp_new */
+  "annoy objects",        /* tp_doc */
+  0,                      /* tp_traverse */
+  0,                      /* tp_clear */
+  0,                      /* tp_richcompare */
+  0,                      /* tp_weaklistoffset */
+  0,                      /* tp_iter */
+  0,                      /* tp_iternext */
+  AnnoyMethods,           /* tp_methods */
+  py_annoy_members,       /* tp_members */
+  0,                      /* tp_getset */
+  0,                      /* tp_base */
+  0,                      /* tp_dict */
+  0,                      /* tp_descr_get */
+  0,                      /* tp_descr_set */
+  0,                      /* tp_dictoffset */
+  (initproc)py_an_init,   /* tp_init */
+  0,                      /* tp_alloc */
+  py_an_new,              /* tp_new */
 };
 
 static PyMethodDef module_methods[] = {

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -14,87 +14,490 @@
 
 #include "annoylib.h"
 #include "Python.h"
-#include <boost/python.hpp>
+#include "structmember.h"
 #include <exception>
 #include <stdint.h>
 
-using namespace std;
-using namespace boost;
-
-
-struct ErrnoException : std::exception {};
-
-void TranslateException(ErrnoException const& e) {
-  PyErr_SetFromErrno(PyExc_IOError);
-}
 
 template<typename S, typename T, typename Distance>
 class AnnoyIndexPython : public AnnoyIndex<S, T, Distance > {
 public:
-  AnnoyIndexPython(int f): AnnoyIndex<S, T, Distance>(f) {}
-  void add_item_py(S item, const python::list& v) {
-    vector<T> w;
-    for (int z = 0; z < this->_f; z++)
-      w.push_back(python::extract<T>(v[z]));
 
+  AnnoyIndexPython(int f): AnnoyIndex<S, T, Distance>(f) {}
+
+  void add_item_py(S item, const vector<T> w) {
     this->add_item(item, &w[0]);
   }
-  python::list get_nns_by_item_py(S item, size_t n) {
+
+  PyObject* get_nns_by_item_py(S item, size_t n) {
+    PyObject* l = PyList_New(0);
     vector<S> result;
     this->get_nns_by_item(item, n, &result);
-    python::list l;
-    for (size_t i = 0; i < result.size(); i++)
-      l.append(result[i]);
-    return l;
-  }
-  python::list get_nns_by_vector_py(python::list v, size_t n) {
-    vector<T> w(this->_f);
-    for (int z = 0; z < this->_f; z++)
-      w[z] = python::extract<T>(v[z]);
-    vector<S> result;
-    this->get_nns_by_vector(&w[0], n, &result);
-    python::list l;
-    for (size_t i = 0; i < result.size(); i++)
-      l.append(result[i]);
-    return l;
-  }
-  python::list get_item_vector_py(S item) {
-    const typename Distance::node* m = this->_get(item);
-    const T* v = m->v;
-    python::list l;
-    for (int z = 0; z < this->_f; z++) {
-      l.append(v[z]);
+    for (size_t i = 0; i < result.size(); i++) {
+      PyList_Append(l, PyInt_FromLong(result[i]));
     }
     return l;
   }
-  void save_py(const string& filename) {
-    if (!this->save(filename))
-      throw ErrnoException();
+
+  PyObject* get_nns_by_vector_py(PyObject* v, size_t n) {
+    vector<T> w(this->_f);
+    for (int z = 0; z < PyList_Size(v); z++) {
+        PyObject *pf = PyList_GetItem(v,z);
+        w.push_back(PyFloat_AsDouble(pf));
+    }
+    vector<S> result;
+    this->get_nns_by_vector(&w[0], n, &result);
+    PyObject* l = PyList_New(0);
+    for (size_t i = 0; i < result.size(); i++) {
+      PyList_Append(l, PyInt_FromLong(result[i]));
+    }
+    return l;
   }
-  void load_py(const string& filename) {
-    if (!this->load(filename))
-      throw ErrnoException();
+
+  PyObject* get_item_vector_py(S item) {
+    const typename Distance::node* m = this->_get(item);
+    const T* v = m->v;
+    PyObject* l = PyList_New(0);
+    for (int z = 0; z < this->_f; z++) {
+      PyList_Append(l, PyInt_FromLong(v[z]));
+    }
+    return l;
   }
+
+  bool save_py(const char* filename) {
+    return this->save(filename);
+  }
+
+  bool load_py(const char* filename) {
+    return this->load(filename);
+  }
+
 };
 
-template<typename C>
-void expose_methods(python::class_<C> c) {
-  c.def("add_item",          &C::add_item_py)
-    .def("build",             &C::build)
-    .def("save",              &C::save_py)
-    .def("load",              &C::load_py)
-    .def("unload",            &C::unload)
-    .def("get_distance",      &C::get_distance)
-    .def("get_nns_by_item",   &C::get_nns_by_item_py)
-    .def("get_nns_by_vector", &C::get_nns_by_vector_py)
-    .def("get_item_vector",   &C::get_item_vector_py)
-    .def("get_n_items",       &C::get_n_items)
-    .def("verbose",           &C::verbose);
+
+class AI : public AnnoyIndexPython <int32_t, float, Angular<int32_t, float> > {
+  public:
+  AI(int f) : AnnoyIndexPython <int32_t, float, Angular<int32_t, float> >(f){};
+};
+class EI : public AnnoyIndexPython <int32_t, float, Euclidean<int32_t, float> > {
+  public:
+  EI(int f) : AnnoyIndexPython <int32_t, float, Euclidean<int32_t, float> >(f){};
+};
+
+
+// annoy python object
+typedef struct {
+  PyObject_HEAD
+  int f;
+  char ch_metric;
+  void* ptr;
+} py_annoy;
+
+
+static PyObject *
+py_an_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
+  py_annoy *self;
+
+  self = (py_annoy *)type->tp_alloc(type, 0);
+  if (self != NULL) {
+    self->f = 0;
+    self->ch_metric = 0;
+    self->ptr = NULL;
+  }
+
+  return (PyObject *)self;
 }
 
-BOOST_PYTHON_MODULE(annoylib)
-{
-  python::register_exception_translator<ErrnoException>(&TranslateException);
-  expose_methods(python::class_<AnnoyIndexPython<int32_t, float, Angular<int32_t, float> > >("AnnoyIndexAngular", python::init<int>()));
-  expose_methods(python::class_<AnnoyIndexPython<int32_t, float, Euclidean<int32_t, float> > >("AnnoyIndexEuclidean", python::init<int>()));
+
+static int 
+py_an_init(py_annoy *self, PyObject *args, PyObject *kwds) {
+  const char *metric;
+
+  if (!PyArg_ParseTuple(args, "is", &self->f, &metric))
+    return -1;
+  self->ch_metric = metric[0];
+  AI *ai; EI *ei;
+  switch(self->ch_metric) {
+  case 'a':
+    ai = new AI(self->f);
+    self->ptr = static_cast<AI*>(static_cast<void*>(ai));
+    break;
+  case 'e':
+    ei = new EI(self->f);
+    self->ptr = static_cast<EI*>(static_cast<void*>(ei));
+    break;
+  }
+  return 0;
 }
+
+
+static void 
+py_an_dealloc(py_annoy* self) {
+  if (self->ptr) {
+    switch(self->ch_metric) {
+    case 'a':
+      delete (AI*)self->ptr;
+      break;
+    case 'e':
+      delete (EI*)self->ptr;
+      break;
+    }
+  }
+  self->ob_type->tp_free((PyObject*)self);
+}
+
+
+static PyMemberDef py_annoy_members[] = {
+  {(char*)"_f", T_INT, offsetof(py_annoy, f), 0,
+   (char*)""},
+  {(char*)"ch_metric", T_CHAR, offsetof(py_annoy, ch_metric), 0,
+   (char*)"a|e for angular|euclidean"},
+  {NULL}	/* Sentinel */
+};
+
+
+static PyObject *
+py_an_load(py_annoy *self, PyObject *args) {
+  char* filename;
+  bool res = false;
+  if (!self->ptr) 
+    return Py_None;
+  if (!PyArg_ParseTuple(args, "s", &filename))
+    return Py_None;
+  AI *ai; EI *ei;
+  switch(self->ch_metric) {
+  case 'a':
+    ai = static_cast<AI*>(self->ptr);
+    res = ai->load_py(filename);
+    break;
+  case 'e':
+    ei = static_cast<EI*>(self->ptr);
+    res = ei->load_py(filename);
+    break;
+  }
+  if (!res) {
+    PyErr_SetString(PyExc_IOError,"load error");
+    return NULL;
+  }
+  return PyInt_FromLong(0);
+}
+
+
+static PyObject *
+py_an_save(py_annoy *self, PyObject *args) {
+  char *filename;
+  bool res = false;
+  if (!self->ptr) 
+    return Py_None;
+  if (!PyArg_ParseTuple(args, "s", &filename))
+    return Py_None;
+  AI *ai; EI *ei;
+  switch(self->ch_metric) {
+  case 'a':
+    ai = static_cast<AI*>(self->ptr);
+    res = ai->save_py(filename);
+    break;
+  case 'e':
+    ei = static_cast<EI*>(self->ptr);
+    res = ei->save_py(filename);
+    break;
+  }
+  if (!res) {
+    PyErr_SetString(PyExc_IOError,"load error");
+    return NULL;
+  }
+  return PyInt_FromLong(0);
+}
+
+
+static PyObject* 
+py_an_get_nns_by_item(py_annoy *self, PyObject *args) {
+  PyObject* l = PyList_New(0);
+  int32_t item, n;
+  if (!self->ptr) 
+    return Py_None;
+  if (!PyArg_ParseTuple(args, "ii", &item, &n))
+    return Py_None;
+  AI *ai; EI *ei;
+  switch(self->ch_metric) {
+  case 'a':
+    ai = static_cast<AI*>(self->ptr);
+    l = ai->get_nns_by_item_py(item, (size_t)n);
+    break;
+  case 'e':
+    ei = static_cast<EI*>(self->ptr);
+    l = ei->get_nns_by_item_py(item, (size_t)n);
+    break;
+  }
+  return l;
+}
+
+
+static PyObject* 
+py_an_get_nns_by_vector(py_annoy *self, PyObject *args) {
+  PyObject* v;
+  PyObject* l = PyList_New(0);
+  int32_t n;
+  if (!self->ptr) 
+    return Py_None;
+  if (!PyArg_ParseTuple(args, "Oi", &v, &n))
+    return Py_None;
+  AI *ai; EI *ei;
+  switch(self->ch_metric) {
+  case 'a':
+    ai = static_cast<AI*>(self->ptr);
+    l = ai->get_nns_by_vector_py(v, (size_t)n);
+    break;
+  case 'e':
+    ei = static_cast<EI*>(self->ptr);
+    l = ei->get_nns_by_vector_py(v, (size_t)n);
+    break;
+  }
+  return l;
+}
+
+
+static PyObject* 
+py_an_get_item_vector(py_annoy *self, PyObject *args) {
+  PyObject* l = NULL;
+  int32_t item;
+  if (!self->ptr) 
+    return Py_None;
+  if (!PyArg_ParseTuple(args, "i", &item))
+    return Py_None;
+  AI *ai; EI *ei;
+  switch(self->ch_metric) {
+  case 'a':
+    ai = static_cast<AI*>(self->ptr);
+    l = ai->get_item_vector_py(item);
+    break;
+  case 'e':
+    ei = static_cast<EI*>(self->ptr);
+    l = ei->get_item_vector_py(item);
+    break;
+  }
+  if (l) return l;
+  return Py_None;
+}
+
+
+static PyObject* 
+py_an_add_item(py_annoy *self, PyObject *args) {
+  vector<float> w;
+
+  //void add_item_py(S item, const vector<T> w) {
+  PyObject* l;
+  int32_t item;
+  if (!self->ptr) 
+    return Py_None;
+  if (!PyArg_ParseTuple(args, "iO", &item, &l))
+    return Py_None;
+  for (int z = 0; z < PyList_Size(l); z++) {
+    PyObject *pf = PyList_GetItem(l,z);
+    w.push_back(PyFloat_AsDouble(pf));
+  }
+  AI *ai; EI *ei;
+  switch(self->ch_metric) {
+  case 'a':
+    ai = static_cast<AI*>(self->ptr);
+    ai->add_item_py(item, w);
+    break;
+  case 'e':
+    ei = static_cast<EI*>(self->ptr);
+    ei->add_item_py(item, w);
+    break;
+  }
+  return PyInt_FromLong(0);
+}
+
+
+static PyObject *
+py_an_build(py_annoy *self, PyObject *args) {
+  int q;
+  if (!self->ptr) 
+    return Py_None;
+  if (!PyArg_ParseTuple(args, "i", &q))
+    return Py_None;
+  AI *ai; EI *ei;
+  switch(self->ch_metric) {
+  case 'a':
+    ai = static_cast<AI*>(self->ptr);
+    ai->build(q);
+    break;
+  case 'e':
+    ei = static_cast<EI*>(self->ptr);
+    ei->build(q);
+    break;
+  }
+  return PyInt_FromLong(0);
+}
+
+
+static PyObject *
+py_an_unload(py_annoy *self, PyObject *args) {
+  if (!self->ptr) 
+    return Py_None;
+  AI *ai; EI *ei;
+  switch(self->ch_metric) {
+  case 'a':
+    ai = static_cast<AI*>(self->ptr);
+    ai->unload();
+    break;
+  case 'e':
+    ei = static_cast<EI*>(self->ptr);
+    ei->unload();
+    break;
+  }
+  return PyInt_FromLong(0);
+}
+
+
+static PyObject *
+py_an_get_distance(py_annoy *self, PyObject *args) {
+  int32_t i,j;
+  double d=0;
+  if (!self->ptr) 
+    return Py_None;
+  if (!PyArg_ParseTuple(args, "ii", &i, &j))
+    return Py_None;
+  AI *ai; EI *ei;
+  switch(self->ch_metric) {
+  case 'a':
+    ai = static_cast<AI*>(self->ptr);
+    d = ai->get_distance(i,j);
+    break;
+  case 'e':
+    ei = static_cast<EI*>(self->ptr);
+    d = ei->get_distance(i,j);
+    break;
+  }
+  return PyFloat_FromDouble(d);
+}
+
+
+static PyObject *
+py_an_get_n_items(py_annoy *self, PyObject *args) {
+  int32_t n=0;
+  bool is_n=false;
+  if (!self->ptr) 
+    return Py_None;
+  AI *ai; EI *ei;
+  switch(self->ch_metric) {
+  case 'a':
+    ai = static_cast<AI*>(self->ptr);
+    n = ai->get_n_items();
+    is_n = true;
+    break;
+  case 'e':
+    ei = static_cast<EI*>(self->ptr);
+    n = ei->get_n_items();
+    is_n = true;
+    break;
+  }
+  if (is_n) return PyInt_FromLong(n);
+  return Py_None;
+}
+
+
+static PyObject *
+py_an_verbose(py_annoy *self, PyObject *args) {
+  int verbose;
+  if (!self->ptr) 
+    return Py_None;
+  if (!PyArg_ParseTuple(args, "i", &verbose))
+    return Py_None;
+  AI *ai; EI *ei;
+  switch(self->ch_metric) {
+  case 'a':
+    ai = static_cast<AI*>(self->ptr);
+    ai->verbose((bool)verbose);
+    break;
+  case 'e':
+    ei = static_cast<EI*>(self->ptr);
+    ei->verbose((bool)verbose);
+    break;
+  }
+  return PyInt_FromLong(0);
+}
+
+
+static PyMethodDef AnnoyMethods[] = {
+  {"load",	(PyCFunction)py_an_load, METH_VARARGS, ""},
+  {"save",	(PyCFunction)py_an_save, METH_VARARGS, ""},
+  {"get_nns_by_item",(PyCFunction)py_an_get_nns_by_item, METH_VARARGS, ""},
+  {"get_nns_by_vector",(PyCFunction)py_an_get_nns_by_vector, METH_VARARGS, ""},
+  {"get_item_vector",(PyCFunction)py_an_get_item_vector, METH_VARARGS, ""},
+  {"add_item",(PyCFunction)py_an_add_item, METH_VARARGS, ""},
+  {"build",(PyCFunction)py_an_build, METH_VARARGS, ""},
+  {"unload",(PyCFunction)py_an_unload, METH_VARARGS, ""},
+  {"get_distance",(PyCFunction)py_an_get_distance, METH_VARARGS, ""},
+  {"get_n_items",(PyCFunction)py_an_get_n_items, METH_VARARGS, ""},
+  {"verbose",(PyCFunction)py_an_verbose, METH_VARARGS, ""},
+  {NULL, NULL, 0, NULL}		 /* Sentinel */
+};
+
+
+static PyTypeObject PyAnnoyType = {
+  PyObject_HEAD_INIT(NULL)
+  0,						 /*ob_size*/
+  "annoy.Annoy",			 /*tp_name*/
+  sizeof(py_annoy),			 /*tp_basicsize*/
+  0,						 /*tp_itemsize*/
+  (destructor)py_an_dealloc, /*tp_dealloc*/
+  0,						 /*tp_print*/
+  0,						 /*tp_getattr*/
+  0,						 /*tp_setattr*/
+  0,						 /*tp_compare*/
+  0,						 /*tp_repr*/
+  0,						 /*tp_as_number*/
+  0,						 /*tp_as_sequence*/
+  0,						 /*tp_as_mapping*/
+  0,						 /*tp_hash */
+  0,						 /*tp_call*/
+  0,						 /*tp_str*/
+  0,						 /*tp_getattro*/
+  0,						 /*tp_setattro*/
+  0,						 /*tp_as_buffer*/
+  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+  "annoy objects",			 /* tp_doc */
+  0,						 /* tp_traverse */
+  0,						 /* tp_clear */
+  0,						 /* tp_richcompare */
+  0,						 /* tp_weaklistoffset */
+  0,						 /* tp_iter */
+  0,						 /* tp_iternext */
+  AnnoyMethods,				 /* tp_methods */
+  py_annoy_members,			 /* tp_members */
+  0,						 /* tp_getset */
+  0,						 /* tp_base */
+  0,						 /* tp_dict */
+  0,						 /* tp_descr_get */
+  0,						 /* tp_descr_set */
+  0,						 /* tp_dictoffset */
+  (initproc)py_an_init,		 /* tp_init */
+  0,						 /* tp_alloc */
+  py_an_new,				 /* tp_new */
+};
+
+static PyMethodDef module_methods[] = {
+  {NULL}	/* Sentinel */
+};
+
+PyMODINIT_FUNC initannoylib(void) {
+  PyObject *m;
+
+  if (PyType_Ready(&PyAnnoyType) < 0)
+    return;
+
+  m = Py_InitModule("annoylib", module_methods);
+  if (m == NULL)
+    return;
+
+  if (m == NULL)
+    return;
+
+  Py_INCREF(&PyAnnoyType);
+  PyModule_AddObject(m, "Annoy", (PyObject *)&PyAnnoyType);
+}
+
+// vim: tabstop=2 shiftwidth=2


### PR DESCRIPTION
1. I added -std=c++11 flag for std::rand support. Tell me, if it matter.

2. EuclideanIndexTest::test_get_nns_by_vector failed, see below. It's in reverse order, but AngularIndexTest::, passed ok. I don't know, how I can receive [1,0], if it include sort call before return.
annoylib.h:
537     sort(nns_dist.begin(), nns_dist.end());
538     for (size_t i = 0; i < nns_dist.size() && result->size() < n; i++) {
539       result->push_back(nns_dist[i].second);
540     }

FAIL: test_get_nns_by_vector (annoy_test.EuclideanIndexTest)

Traceback (most recent call last):
  File "/home/dvenum/devl/annoy/test/annoy_test.py", line 112, in test_get_nns_by_vector
    self.assertEqual(i.get_nns_by_vector([3,3], 2), [1, 0])
AssertionError: Lists differ: [0, 1] != [1, 0]
First differing element 0:
0
1
<div>
-  [0, 1] <br/>
+  [1, 0] <br/>
<br/>
3. If I right, valgrin have clear output, only usually python message. It seems to true, because a small new memory management was delegated to python.
</div>