### PR TITLE
python3 support

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -560,7 +560,7 @@ protected:
       }
     }
 
-    std::sort(nns.begin(), nns.end());
+    sort(nns.begin(), nns.end());
     vector<pair<T, S> > nns_dist;
     S last = -1;
     for (size_t i = 0; i < nns.size(); i++) {


### PR DESCRIPTION
All tests passed.
Don't worry about new library name annoylib.cpython-34m.so (for python34), it's imported as well.
http://legacy.python.org/dev/peps/pep-3149/

sorry, annoylib.h changes was included here.