### PR TITLE
Make add_item() not verbose

### DIFF
--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -205,7 +205,7 @@ py_an_add_item(py_annoy *self, PyObject *args) {
   }
   self->ptr->add_item(item, &w[0]);
 
-  return PyInt_FromLong(0);
+  Py_RETURN_NONE;
 }
 
 


### PR DESCRIPTION
Do not return and print 0's when add_item() is called.

Change-Id: Ieb8e3ee43ab3bcaff908c71ba99624ced86e49c4