### PR TITLE
Compiler optimizations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(name='annoy',
       ext_modules=[
         Extension(
             'annoy.annoylib', ['src/annoymodule.cc'],
-            depends=['src/annoylib.h']
+            depends=['src/annoylib.h'],
+            extra_compile_args=['-O3', '-msse2'],
         )
       ],
       long_description=long_description,


### PR DESCRIPTION
Use -O3 and -msse2

Taken from https://github.com/aaalgo/kgraph/blob/master/Makefile

Running nosetests:

```
Before:              113.462s
With -O3:             99.893s
With -O3 and -msse2:  89.678s (Roughly 25% faster)
```