### PR TITLE
Make it possible to specify how many nodes to consider during search

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Full Python API
 * ``a.save(fn)`` saves the index to disk.
 * ``a.load(fn)`` loads (mmaps) an index from disk.
 * ``a.unload(fn)`` unloads.
-* ``a.get_nns_by_item(i, n)`` returns the ``n`` closest items. During the query it will inspect up to ``n_trees * n`` nodes. Note that for better performance you might want to oversample ``n``, eg. to fetch the top 100 items with higher precision, do ``a.get_nns_by_item(i, 1000)[:100]``. Also note that the array returned will include ``i`` as the first element.
+* ``a.get_nns_by_item(i, n, search_k=-1)`` returns the ``n`` closest items. During the query it will inspect up to ``search_k`` nodes which defaults to ``n_trees * n`` if not provided. ``search_k`` gives you a run-time tradeoff between better accuracy and speed.
 * ``a.get_nns_by_vector(v, n)`` same but query by vector ``v``.
 * ``a.get_item_vector_item(i)`` returns the vector for item ``i`` that was previously added.
 * ``a.get_distance(i, j)`` returns the distance between items ``i`` and ``j``.

--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,16 @@ Note that there's no bounds checking performed on the values so be careful.
 
 The C++ API is very similar: just ``#include "annoylib.h"`` to get access to it.
 
+Tradeoffs
+---------
+
+There are just two parameters you can use to tune Annoy: the number of trees ``n_trees`` and the number of nodes to inspect during searching ``search_k``.
+
+* ``n_trees`` is provided during build time and affects the build time and the index size. A larger value will give more accurate results, but larger indexes.
+* ``search_k`` is provided in runtime and affects the search performance. A larger value will give more accurate results, but will take longer time to return.
+
+If ``search_k`` is not provided, it will default to ``n * n_trees`` where ``n`` is the number of approximate nearest neighbors. Otherwise, ``search_k`` and ``n_trees`` are roughly independent, i.e. a the value of ``n_trees`` will not affect search time if ``search_k`` is held constant and vice versa. Basically it's recommended to set ``n_trees`` as large as possible given the amount of memory you can afford, and it's recommended to set ``search_k`` as large as possible given the time constraints you have for the queries.
+
 How does it work
 ----------------
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ with open('README.rst') as fobj:
 
 
 setup(name='annoy',
-      version='1.3.2',
+      version='1.4.1',
       description='Approximate Nearest Neighbors in C++/Python optimized for memory usage and loading/saving to disk.',
       packages=['annoy'],
       ext_modules=[

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -130,15 +130,15 @@ py_an_save(py_annoy *self, PyObject *args) {
 
 static PyObject* 
 py_an_get_nns_by_item(py_annoy *self, PyObject *args) {
-  int32_t item, n;
+  int32_t item, n, search_k=-1;
   if (!self->ptr) 
     return Py_None;
-  if (!PyArg_ParseTuple(args, "ii", &item, &n))
+  if (!PyArg_ParseTuple(args, "ii|i", &item, &n, &search_k))
     return Py_None;
 
   PyObject* l = PyList_New(0);
   vector<int32_t> result;
-  self->ptr->get_nns_by_item(item, n, &result);
+  self->ptr->get_nns_by_item(item, n, &result, search_k);
   for (size_t i = 0; i < result.size(); i++) {
     PyList_Append(l, PyInt_FromLong(result[i]));
   }
@@ -149,10 +149,10 @@ py_an_get_nns_by_item(py_annoy *self, PyObject *args) {
 static PyObject* 
 py_an_get_nns_by_vector(py_annoy *self, PyObject *args) {
   PyObject* v;
-  int32_t n;
+  int32_t n, search_k=-1;
   if (!self->ptr) 
     return Py_None;
-  if (!PyArg_ParseTuple(args, "Oi", &v, &n))
+  if (!PyArg_ParseTuple(args, "Oi|i", &v, &n, &search_k))
     return Py_None;
 
   vector<float> w(self->f);
@@ -161,7 +161,7 @@ py_an_get_nns_by_vector(py_annoy *self, PyObject *args) {
     w[z] = PyFloat_AsDouble(pf);
   }
   vector<int32_t> result;
-  self->ptr->get_nns_by_vector(&w[0], n, &result);
+  self->ptr->get_nns_by_vector(&w[0], n, &result, search_k);
   PyObject* l = PyList_New(0);
   for (size_t i = 0; i < result.size(); i++) {
     PyList_Append(l, PyInt_FromLong(result[i]));

--- a/test/accuracy_test.py
+++ b/test/accuracy_test.py
@@ -56,8 +56,10 @@ class AccuracyTest(unittest.TestCase):
         n, k = 0, 0
 
         for i in range(10000):
-            js_fast = annoy.get_nns_by_item(i, 11)[1:11]
-            js_slow = annoy.get_nns_by_item(i, 1001)[1:11]
+            js_fast = annoy.get_nns_by_item(i, 11)[1:]
+            js_slow = annoy.get_nns_by_item(i, 11, 10000)[1:]
+            assert len(js_fast) == 10
+            assert len(js_slow) == 10
 
             n += 10
             k += len(set(js_fast).intersection(js_slow))

--- a/test/annoy_test.py
+++ b/test/annoy_test.py
@@ -152,6 +152,17 @@ class AngularIndexTest(unittest.TestCase):
         self.assertTrue(j.load('blah.ann'))
         numpy.testing.assert_array_almost_equal(j.get_item_vector(2), [7.7, 8.8, 9.9])
 
+    def test_get_nns_search_k(self):
+        f = 3
+        i = AnnoyIndex(f)
+        i.add_item(0, [0, 0, 1])
+        i.add_item(1, [0, 1, 0])
+        i.add_item(2, [1, 0, 0])
+        i.build(10)
+
+        self.assertEqual(i.get_nns_by_item(0, 3, 10), [0, 1, 2])
+        self.assertEqual(i.get_nns_by_vector([3, 2, 1], 3, 10), [2, 1, 0])
+
 
 class EuclideanIndexTest(unittest.TestCase):
     def test_get_nns_by_vector(self):


### PR DESCRIPTION
Also made a bunch of speed optimizations since now you don't have to return all items to Python

This is not a substantial speedup, but still 10-40%. It also simplifies the API somewhat.

![image](https://cloud.githubusercontent.com/assets/1027979/8365691/0abc1538-1b8f-11e5-90a1-ae6fc182a5e0.png)
