### PR TITLE
Slightly faster searches

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -510,6 +510,7 @@ protected:
     vector<S> nns;
     while (nns.size() < search_k && !q.empty()) {
       const pair<T, S>& top = q.top();
+      T d = top.first;
       S i = top.second;
       const typename Distance::node* nd = _get(top.second);
       q.pop();
@@ -520,8 +521,8 @@ protected:
         nns.insert(nns.end(), nd->children, &dst[nd->n_descendants]);
       } else {
         T margin = Distance::margin(nd, v, _f);
-        q.push(make_pair(+margin, nd->children[1]));
-        q.push(make_pair(-margin, nd->children[0]));
+        q.push(make_pair(std::min(d, +margin), nd->children[1]));
+        q.push(make_pair(std::min(d, -margin), nd->children[0]));
       }
     }
 


### PR DESCRIPTION
Instead of just putting the margin into the heap, we put the minimum margin seen across all nodes in the path from the root.

On my computer it takes the test time from 70s -> 62s which is a 13% improvement. Not huge but not bad for such a small fix