### PR TITLE
Minor cache locality improvements

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -506,7 +506,7 @@ protected:
   void _get_all_nns(const T* v, size_t n, vector<S>* result, size_t search_k) {
     std::priority_queue<pair<T, S> > q;
 
-    if (search_k == -1)
+    if (search_k == (size_t)-1)
       search_k = n * _roots.size(); // slightly arbitrary default value
 
     for (size_t i = 0; i < _roots.size(); i++) {

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -488,12 +488,12 @@ protected:
       }
     }
 
-    S children_0 = _make_tree(children_indices[0]);
-    S children_1 = _make_tree(children_indices[1]);
+    int flip = (children_indices[0].size() > children_indices[1].size());
 
     m->n_descendants = (S)indices.size();
-    m->children[0] = children_0;
-    m->children[1] = children_1;
+    for (int side = 0; side < 2; side++)
+      // run _make_tree for the smallest child first (for cache locality)
+      m->children[side^flip] = _make_tree(children_indices[side^flip]);
 
     _allocate_size(_n_nodes + 1);
     S item = _n_nodes++;


### PR DESCRIPTION
Be a bit smarter about building trees

1. Put the parent node *after* the child nodes.
2. Put the biggest child node last

After the fix, with P>0.5, the best child node will be located right next to the parent node, improving cache locality slightly.