### PR TITLE
Tests for angular distances and fix small bug

### DIFF
--- a/annoy/__init__.py
+++ b/annoy/__init__.py
@@ -36,3 +36,7 @@ class AnnoyIndex(Annoy):
     def get_nns_by_vector(self, vector, n, search_k=-1, include_distances=False):
         # Same
         return super(AnnoyIndex, self).get_nns_by_vector(self.check_list(vector), n, search_k, include_distances)
+
+    def get_nns_by_item(self, i, n, search_k=-1, include_distances=False):
+        # Wrapper to support named arguments
+        return super(AnnoyIndex, self).get_nns_by_item(i, n, search_k, include_distances)

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -154,7 +154,9 @@ struct Angular {
   }
   static inline T normalized_distance(T distance) {
     // Used when requesting distances from Python layer
-    return sqrt(distance);
+    // Turns out sometimes the squared distance is -0.0
+    // so we have to make sure it's a positive number.
+    return sqrt(std::max(distance, T(0)));
   }
 };
 
@@ -201,7 +203,7 @@ struct Euclidean {
       n->a += -n->v[z] * (iv[z] + jv[z]) / 2;
   }
   static inline T normalized_distance(T distance) {
-    return sqrt(distance);
+    return sqrt(std::max(distance, T(0)));
   }
 };
 

--- a/test/annoy_test.py
+++ b/test/annoy_test.py
@@ -30,7 +30,7 @@ except NameError:
 class TestCase(unittest.TestCase):
     def assertAlmostEquals(self, x, y):
         # Annoy uses float precision, so we override the default precision
-        super(TestCase, self).assertAlmostEquals(x, y, 4)
+        super(TestCase, self).assertAlmostEquals(x, y, 3)
 
 
 class AngularIndexTest(TestCase):

--- a/test/annoy_test.py
+++ b/test/annoy_test.py
@@ -296,6 +296,18 @@ class EuclideanIndexTest(TestCase):
         self.assertAlmostEquals(d[1]**2, 8.0)
         self.assertAlmostEquals(d[2]**2, 9.0)
 
+    def test_include_dists(self):
+        f = 40
+        i = AnnoyIndex(f)
+        v = numpy.random.normal(size=f)
+        i.add_item(0, v)
+        i.add_item(1, -v)
+        i.build(10)
+
+        indices, dists = i.get_nns_by_item(0, 2, 10, True)
+        self.assertEqual(indices, [0, 1])
+        self.assertAlmostEquals(dists[0], 0.0)
+
 
 class IndexTest(TestCase):
     def test_not_found_tree(self):

--- a/test/annoy_test.py
+++ b/test/annoy_test.py
@@ -169,6 +169,30 @@ class AngularIndexTest(TestCase):
         self.assertEqual(i.get_nns_by_item(0, 3, 10), [0, 1, 2])
         self.assertEqual(i.get_nns_by_vector([3, 2, 1], 3, 10), [2, 1, 0])
 
+    def test_include_dists(self):
+        # Double checking issue 112
+        f = 40
+        i = AnnoyIndex(f)
+        v = numpy.random.normal(size=f)
+        i.add_item(0, v)
+        i.add_item(1, -v)
+        i.build(10)
+
+        indices, dists = i.get_nns_by_item(0, 2, 10, True)
+        self.assertEqual(indices, [0, 1])
+        self.assertAlmostEquals(dists[0], 0.0)
+        self.assertAlmostEquals(dists[1], 2.0)
+
+    def test_include_dists_check_ranges(self):
+        f = 3
+        i = AnnoyIndex(f)
+        for j in xrange(100000):
+            i.add_item(j, numpy.random.normal(size=f))
+        i.build(10)
+        indices, dists = i.get_nns_by_item(0, 100000, include_distances=True)
+        self.assertTrue(max(dists) < 2.0)
+        self.assertAlmostEquals(min(dists), 0.0)
+
 
 class EuclideanIndexTest(TestCase):
     def test_get_nns_by_vector(self):


### PR DESCRIPTION
Added some tests to verify #112 and realized there was a bug causing distances for identical vectors to be returned as `nan` sometimes