### PR TITLE
Python Docstrings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Full Python API
 * ``a.build(n_trees)`` builds a forest of ``n_trees`` trees. More trees gives higher precision when querying. After calling ``build``, no more items can be added.
 * ``a.save(fn)`` saves the index to disk.
 * ``a.load(fn)`` loads (mmaps) an index from disk.
-* ``a.unload(fn)`` unloads.
+* ``a.unload()`` unloads.
 * ``a.get_nns_by_item(i, n, search_k=-1, include_distances=False)`` returns the ``n`` closest items. During the query it will inspect up to ``search_k`` nodes which defaults to ``n_trees * n`` if not provided. ``search_k`` gives you a run-time tradeoff between better accuracy and speed. If you set ``include_distances`` to ``True``, it will return a 2 element tuple with two lists in it: the second one containing all corresponding distances.
 * ``a.get_nns_by_vector(v, n, search_k=-1, include_distances=False)`` same but query by vector ``v``.
 * ``a.get_item_vector(i)`` returns the vector for item ``i`` that was previously added.

--- a/annoy/__init__.py
+++ b/annoy/__init__.py
@@ -17,6 +17,8 @@ from .annoylib import *
 class AnnoyIndex(Annoy):
     def __init__(self, f, metric='angular'):
         """
+        Initializes an AnnoyIndex that stores vectors of `f` dimensions.
+
         :param metric: 'angular' or 'euclidean'
         """
         self.f = f
@@ -30,13 +32,85 @@ class AnnoyIndex(Annoy):
         return vector
 
     def add_item(self, i, vector):
+        """
+        Adds item `i` (any nonnegative integer) with vector `v`.
+
+        Note that it will allocate memory for `max(i)+1` items.
+        """
         # Wrapper to convert inputs to list
         return super(AnnoyIndex, self).add_item(i, self.check_list(vector))
 
     def get_nns_by_vector(self, vector, n, search_k=-1, include_distances=False):
+        """
+        Returns the `n` closest items to vector `vector`.
+
+        :param search_k: the query will inspect up to `search_k` nodes.
+        `search_k` gives you a run-time tradeoff between better accuracy and speed.
+        `search_k` defaults to `n_trees * n` if not provided.
+
+        :param include_distances: If `True`, this function will return a
+        2 element tuple of lists. The first list contains the `n` closest items.
+        The second list contains the corresponding distances.
+        """
         # Same
         return super(AnnoyIndex, self).get_nns_by_vector(self.check_list(vector), n, search_k, include_distances)
 
     def get_nns_by_item(self, i, n, search_k=-1, include_distances=False):
+        """
+        Returns the `n` closest items to item `i`.
+
+        :param search_k: the query will inspect up to `search_k` nodes.
+        `search_k` gives you a run-time tradeoff between better accuracy and speed.
+        `search_k` defaults to `n_trees * n` if not provided.
+
+        :param include_distances: If `True`, this function will return a
+        2 element tuple of lists. The first list contains the `n` closest items.
+        The second list contains the corresponding distances.
+        """
         # Wrapper to support named arguments
         return super(AnnoyIndex, self).get_nns_by_item(i, n, search_k, include_distances)
+
+    def build(self, n_trees):
+        """
+        Builds a forest of `n_trees` trees.
+
+        More trees give higher precision when querying. After calling `build`,
+        no more items can be added.
+        """
+        return super(AnnoyIndex, self).build(n_trees)
+
+    def save(self, fn):
+        """
+        Saves the index to disk.
+        """
+        return super(AnnoyIndex, self).save(fn)
+
+    def load(self, fn):
+        """
+        Loads (mmaps) an index from disk.
+        """
+        return super(AnnoyIndex, self).load(fn)
+
+    def unload(self):
+        """
+        Unloads an index from disk.
+        """
+        return super(AnnoyIndex, self).unload()
+
+    def get_item_vector(self, i):
+        """
+        Returns the vector for item `i` that was previously added.
+        """
+        return super(AnnoyIndex, self).get_item_vector(i)
+
+    def get_distance(self, i, j):
+        """
+        Returns the distance between items `i` and `j`.
+        """
+        return super(AnnoyIndex, self).get_distance(i, j)
+
+    def get_n_items(self):
+        """
+        Returns the number of items in the index.
+        """
+        return super(AnnoyIndex, self).get_n_items()


### PR DESCRIPTION
This adds docstrings to the Python bindings. This also fixes an error in the documentation of the `unload` method. The docs say that it takes a single argument, but the code doesn't accept any.