### PR TITLE
normalize splits for angular

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -182,6 +182,7 @@ struct Angular {
     two_means<T, Random, Angular, Node<S, T> >(nodes, f, random, true, &best_iv[0], &best_jv[0]);
     for (int z = 0; z < f; z++)
       n->v[z] = best_iv[z] - best_jv[z];
+    normalize(n->v, f);
   }
   template<typename T>
   static inline T normalized_distance(T distance) {


### PR DESCRIPTION
found by @nicolamontecchio in issue #142

glove angular 100 dim:
```
before  79.53%  4.233s
after   79.58%  4.027s
```