### PR TITLE
Use binary fopen option.

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -343,7 +343,7 @@ public:
   }
 
   bool save(const char* filename) {
-    FILE *f = fopen(filename, "w");
+    FILE *f = fopen(filename, "wb");
     if (f == NULL)
       return false;
 


### PR DESCRIPTION
Fixes #144, indexes created in Windows.
