### PR TITLE
go: download from googleapis.com

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,15 +12,16 @@ commands =
 [testenv:go]
 setenv =
   GOPATH = {env:HOME:}/gopath
-  GOROOT = /usr/lib/go
+  GOROOT = /usr/local/go
 whitelist_externals=*
 commands =
   mkdir -p {env:GOPATH:}/src/annoyindex
-  sudo add-apt-repository -y ppa:evarlast/golang1.5
+  wget https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz
+  sudo tar -C /usr/local -xzf go1.5.linux-amd64.tar.gz
   sudo add-apt-repository -y ppa:rosmo/swig3.0.7
   sudo apt-get update -qq
-  sudo apt-get install -y swig3.0 golang
+  sudo apt-get install -y swig3.0
   swig3.0 -go -intgosize 64 -cgo -c++ src/annoygomodule.i
   cp src/annoygomodule_wrap.cxx src/annoyindex.go src/annoygomodule.h src/annoylib.h src/kissrandom.h {env:GOPATH:}/src/annoyindex
-  /usr/bin/golang-go build annoyindex
+  {env:GOROOT}/bin/go build annoyindex
 


### PR DESCRIPTION
ppa:evarlast/golang1.5 was deleted.

New method of inslatting Go was found at https://github.com/sameersbn/docker-gitlab/issues/635