### PR TITLE
Support for threads

### DIFF
--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -159,7 +159,10 @@ py_an_get_nns_by_item(py_annoy *self, PyObject *args) {
 
   vector<int32_t> result;
   vector<float> distances;
+
+  Py_BEGIN_ALLOW_THREADS;
   self->ptr->get_nns_by_item(item, n, search_k, &result, include_distances ? &distances : NULL);
+  Py_END_ALLOW_THREADS;
 
   return get_nns_to_python(result, distances, include_distances);
 }
@@ -182,7 +185,10 @@ py_an_get_nns_by_vector(py_annoy *self, PyObject *args) {
 
   vector<int32_t> result;
   vector<float> distances;
+
+  Py_BEGIN_ALLOW_THREADS;
   self->ptr->get_nns_by_vector(&w[0], n, search_k, &result, include_distances ? &distances : NULL);
+  Py_END_ALLOW_THREADS;
 
   return get_nns_to_python(result, distances, include_distances);
 }

--- a/test/annoy_test.py
+++ b/test/annoy_test.py
@@ -18,6 +18,7 @@
 import unittest
 import random
 import numpy
+import multiprocessing.pool
 from annoy import AnnoyIndex
 
 try:
@@ -407,6 +408,7 @@ class TypesTest(TestCase):
             self.assertRaises(IndexError, i.get_nns_by_item, bad_index, 1)
             self.assertRaises(IndexError, i.get_item_vector, bad_index)
 
+
 class MemoryLeakTest(TestCase):
     def test_get_item_vector(self):
         f = 10
@@ -424,3 +426,17 @@ class MemoryLeakTest(TestCase):
         i.build(10)
         for j in xrange(100):
             self.assertEquals(i.get_nns_by_item(0, 999999999), [0])
+
+
+class ThreadingTest(TestCase):
+    def test_threads(self):
+        n, f = 10000, 10
+        i = AnnoyIndex(f, 'euclidean')
+        for j in xrange(n):
+            i.add_item(j, numpy.random.normal(size=f))
+        i.build(10)
+
+        pool = multiprocessing.pool.ThreadPool()
+        def query_f(j):
+            i.get_nns_by_item(1, 1000)
+        pool.map(query_f, range(n))


### PR DESCRIPTION
This is partly so we can max out the CPU cores while running ann-benchmarks (since other libraries might be multithreaded)

See https://github.com/erikbern/ann-benchmarks/pull/28#issuecomment-231733072