### PR TITLE
Fix distance inconsistency for angular distance

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Annoy was built by `Erik Bernhardsson <http://www.erikbern.com>`__ in a couple o
 Summary of features
 -------------------
 
-* Euclidean distance or cosine distance (where cosine distance uses Euclidean distance of normalized vectors which equals 2-2*cosine similarity)
+* Euclidean distance or cosine distance, where cosine distance uses Euclidean distance of normalized vectors = sqrt(2-2*cos(u, v))
 * Works better if you don't have too many dimensions (like <100) but seems to perform surprisingly well even up to 1,000 dimensions
 * Small memory usage
 * Lets you share memory between multiple processes
@@ -83,8 +83,8 @@ Full Python API
 
 Notes:
 
-* there's no bounds checking performed on the values so be careful.
-* annoy uses euclidean distance of normalized vectors for its angular distance, which for two vectors u,v is equal to ``2(1-cos(u,v))``
+* There's no bounds checking performed on the values so be careful.
+* Annoy uses Euclidean distance of normalized vectors for its angular distance, which for two vectors u,v is equal to ``sqrt(2(1-cos(u,v)))``
 
 
 The C++ API is very similar: just ``#include "annoylib.h"`` to get access to it.

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Full Python API
 * ``a.get_nns_by_item(i, n, search_k=-1, include_distances=False)`` returns the ``n`` closest items. During the query it will inspect up to ``search_k`` nodes which defaults to ``n_trees * n`` if not provided. ``search_k`` gives you a run-time tradeoff between better accuracy and speed. If you set ``include_distances`` to ``True``, it will return a 2 element tuple with two lists in it: the second one containing all corresponding distances.
 * ``a.get_nns_by_vector(v, n, search_k=-1, include_distances=False)`` same but query by vector ``v``.
 * ``a.get_item_vector(i)`` returns the vector for item ``i`` that was previously added.
-* ``a.get_distance(i, j)`` returns the distance between items ``i`` and ``j``.
+* ``a.get_distance(i, j)`` returns the distance between items ``i`` and ``j``. NOTE: this used to returned the *squared* distance, but has been changed as of Aug 2016.
 * ``a.get_n_items()`` returns the number of items in the index.
 
 Notes:

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -430,7 +430,7 @@ public:
   T get_distance(S i, S j) {
     const T* x = _get(i)->v;
     const T* y = _get(j)->v;
-    return D::distance(x, y, _f);
+    return D::normalized_distance(D::distance(x, y, _f));
   }
 
   void get_nns_by_item(S item, size_t n, size_t search_k, vector<S>* result, vector<T>* distances) {

--- a/test/annoy_test.lua
+++ b/test/annoy_test.lua
@@ -171,7 +171,7 @@ describe("angular annoy test", function()
         local i = AnnoyIndex(f)
         i:add_item(0, {0, 1})
         i:add_item(1, {1, 1})
-        assert.equal(round(2 * (1.0 - 2 ^ -0.5)), round(i:get_distance(0, 1)))
+        assert.equal(round((2 * (1.0 - 2 ^ -0.5)) ^ 0.5), round(i:get_distance(0, 1)))
     end)
 
     it("dist_2", function()
@@ -187,7 +187,7 @@ describe("angular annoy test", function()
         local i = AnnoyIndex(f)
         i:add_item(0, {97, 0})
         i:add_item(1, {42, 42})
-        local dist = (1 - 2 ^ -0.5) ^ 2 + (2 ^ -0.5) ^ 2
+        local dist = ((1 - 2 ^ -0.5) ^ 2 + (2 ^ -0.5) ^ 2) ^ 0.5
         assert.equal(round(dist), round(i:get_distance(0, 1)))
     end)
 
@@ -196,7 +196,7 @@ describe("angular annoy test", function()
         local i = AnnoyIndex(f)
         i:add_item(0, {1, 0})
         i:add_item(1, {0, 0})
-        assert.equal(round(2.0), round(i:get_distance(0, 1)))
+        assert.equal(round(2.0 ^ 0.5), round(i:get_distance(0, 1)))
     end)
 
     it("large_index", function()

--- a/test/annoy_test.py
+++ b/test/annoy_test.py
@@ -20,7 +20,9 @@ import random
 import numpy
 import multiprocessing.pool
 from annoy import AnnoyIndex
-from scipy.spatial.distance import cosine, euclidean
+# Travis craps out on Scipy sadly
+# from scipy.spatial.distance import cosine, euclidean
+
 
 try:
     xrange
@@ -209,9 +211,9 @@ class AngularIndexTest(TestCase):
                 v = i.get_item_vector(b)
                 u_norm = numpy.array(u) * numpy.dot(u, u)**-0.5
                 v_norm = numpy.array(v) * numpy.dot(v, v)**-0.5
-                cos = numpy.clip(1 - cosine(u, v), -1, 1) # scipy returns 1 - cos
+                # cos = numpy.clip(1 - cosine(u, v), -1, 1) # scipy returns 1 - cos
                 self.assertAlmostEqual(dist, numpy.dot(u_norm - v_norm, u_norm - v_norm) ** 0.5)
-                self.assertAlmostEqual(dist, (2*(1 - cos))**0.5)
+                # self.assertAlmostEqual(dist, (2*(1 - cos))**0.5)
                 self.assertAlmostEqual(dist, sum([(x-y)**2 for x, y in zip(u_norm, v_norm)])**0.5)
 
 
@@ -343,7 +345,7 @@ class EuclideanIndexTest(TestCase):
                 self.assertAlmostEqual(dist, i.get_distance(a, b))
                 u = numpy.array(i.get_item_vector(a))
                 v = numpy.array(i.get_item_vector(b))
-                self.assertAlmostEqual(dist, euclidean(u, v))
+                # self.assertAlmostEqual(dist, euclidean(u, v))
                 self.assertAlmostEqual(dist, numpy.dot(u - v, u - v) ** 0.5)
                 self.assertAlmostEqual(dist, sum([(x-y)**2 for x, y in zip(u, v)])**0.5)
 

--- a/test/annoy_test.py
+++ b/test/annoy_test.py
@@ -29,9 +29,9 @@ except NameError:
 
 
 class TestCase(unittest.TestCase):
-    def assertAlmostEquals(self, x, y):
+    def assertAlmostEqual(self, x, y):
         # Annoy uses float precision, so we override the default precision
-        super(TestCase, self).assertAlmostEquals(x, y, 3)
+        super(TestCase, self).assertAlmostEqual(x, y, 3)
 
 
 class AngularIndexTest(TestCase):
@@ -65,7 +65,7 @@ class AngularIndexTest(TestCase):
         i.add_item(0, [0, 1])
         i.add_item(1, [1, 1])
 
-        self.assertAlmostEqual(i.get_distance(0, 1), 2 * (1.0 - 2 ** -0.5))
+        self.assertAlmostEqual(i.get_distance(0, 1), (2 * (1.0 - 2 ** -0.5))**0.5)
 
     def test_dist_2(self):
         f = 2
@@ -81,7 +81,7 @@ class AngularIndexTest(TestCase):
         i.add_item(0, [97, 0])
         i.add_item(1, [42, 42])
 
-        dist = (1 - 2 ** -0.5) ** 2 + (2 ** -0.5) ** 2
+        dist = ((1 - 2 ** -0.5) ** 2 + (2 ** -0.5) ** 2)**0.5
 
         self.assertAlmostEqual(i.get_distance(0, 1), dist)
 
@@ -91,7 +91,7 @@ class AngularIndexTest(TestCase):
         i.add_item(0, [1, 0])
         i.add_item(1, [0, 0])
 
-        self.assertAlmostEqual(i.get_distance(0, 1), 2.0)
+        self.assertAlmostEqual(i.get_distance(0, 1), 2.0**0.5)
 
     def test_large_index(self):
         # Generate pairs of random points where the pair is super close
@@ -181,8 +181,8 @@ class AngularIndexTest(TestCase):
 
         indices, dists = i.get_nns_by_item(0, 2, 10, True)
         self.assertEqual(indices, [0, 1])
-        self.assertAlmostEquals(dists[0], 0.0)
-        self.assertAlmostEquals(dists[1], 2.0)
+        self.assertAlmostEqual(dists[0], 0.0)
+        self.assertAlmostEqual(dists[1], 2.0)
 
     def test_include_dists_check_ranges(self):
         f = 3
@@ -192,7 +192,7 @@ class AngularIndexTest(TestCase):
         i.build(10)
         indices, dists = i.get_nns_by_item(0, 100000, include_distances=True)
         self.assertTrue(max(dists) < 2.0)
-        self.assertAlmostEquals(min(dists), 0.0)
+        self.assertAlmostEqual(min(dists), 0.0)
 
 
 class EuclideanIndexTest(TestCase):
@@ -224,8 +224,10 @@ class EuclideanIndexTest(TestCase):
         i = AnnoyIndex(f, 'euclidean')
         i.add_item(0, [0, 1])
         i.add_item(1, [1, 1])
+        i.add_item(2, [0, 0])
 
-        self.assertAlmostEqual(i.get_distance(0, 1), 1.0)
+        self.assertAlmostEqual(i.get_distance(0, 1), 1.0**0.5)
+        self.assertAlmostEqual(i.get_distance(1, 2), 2.0**0.5)
 
     def test_large_index(self):
         # Generate pairs of random points where the pair is super close
@@ -286,16 +288,16 @@ class EuclideanIndexTest(TestCase):
         i.build(10)
 
         l, d = i.get_nns_by_item(0, 3, -1, True)
-        self.assertEquals(l, [0, 1, 2])
-        self.assertAlmostEquals(d[0]**2, 0.0)
-        self.assertAlmostEquals(d[1]**2, 2.0)
-        self.assertAlmostEquals(d[2]**2, 5.0)
+        self.assertEqual(l, [0, 1, 2])
+        self.assertAlmostEqual(d[0]**2, 0.0)
+        self.assertAlmostEqual(d[1]**2, 2.0)
+        self.assertAlmostEqual(d[2]**2, 5.0)
 
         l, d = i.get_nns_by_vector([2, 2, 2], 3, -1, True)
-        self.assertEquals(l, [1, 0, 2])
-        self.assertAlmostEquals(d[0]**2, 6.0)
-        self.assertAlmostEquals(d[1]**2, 8.0)
-        self.assertAlmostEquals(d[2]**2, 9.0)
+        self.assertEqual(l, [1, 0, 2])
+        self.assertAlmostEqual(d[0]**2, 6.0)
+        self.assertAlmostEqual(d[1]**2, 8.0)
+        self.assertAlmostEqual(d[2]**2, 9.0)
 
     def test_include_dists(self):
         f = 40
@@ -307,7 +309,7 @@ class EuclideanIndexTest(TestCase):
 
         indices, dists = i.get_nns_by_item(0, 2, 10, True)
         self.assertEqual(indices, [0, 1])
-        self.assertAlmostEquals(dists[0], 0.0)
+        self.assertAlmostEqual(dists[0], 0.0)
 
 
 class IndexTest(TestCase):
@@ -320,7 +322,7 @@ class IndexTest(TestCase):
         i.load('test/test.tree')
 
         # This might change in the future if we change the search algorithm, but in that case let's update the test
-        self.assertEquals(i.get_nns_by_item(0, 10), [0, 85, 42, 11, 54, 38, 53, 66, 19, 31])
+        self.assertEqual(i.get_nns_by_item(0, 10), [0, 85, 42, 11, 54, 38, 53, 66, 19, 31])
 
     def test_load_unload(self):
         # Issue #108
@@ -352,11 +354,11 @@ class IndexTest(TestCase):
         u = i.get_item_vector(99)
         i.save('x.tree')
         v = i.get_item_vector(99)
-        self.assertEquals(u, v)
+        self.assertEqual(u, v)
         j = AnnoyIndex(10)
         j.load('test/test.tree')
         w = i.get_item_vector(99)
-        self.assertEquals(u, w)
+        self.assertEqual(u, w)
 
     def test_save_without_build(self):
         # Issue #61
@@ -425,7 +427,7 @@ class MemoryLeakTest(TestCase):
         i.add_item(0, [random.gauss(0, 1) for x in xrange(f)])
         i.build(10)
         for j in xrange(100):
-            self.assertEquals(i.get_nns_by_item(0, 999999999), [0])
+            self.assertEqual(i.get_nns_by_item(0, 999999999), [0])
 
 
 class ThreadingTest(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist=py{26,27,33,34,35}, go, lua
 setenv =
   TRAVIS = {env:TRAVIS:}
 commands =
-  pip install numpy
+  pip install numpy scipy
   pip install .
   python setup.py nosetests
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@ envlist=py{26,27,33,34,35}, go, lua
 setenv =
   TRAVIS = {env:TRAVIS:}
 commands =
-  sudo apt-get install python-numpy python-scipy
+  pip install numpy
+  sudo apt-get install python-scipy
   pip install .
   python setup.py nosetests
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist=py{26,27,33,34,35}, go, lua
 setenv =
   TRAVIS = {env:TRAVIS:}
 commands =
-  pip install numpy scipy
+  sudo apt-get install python-numpy python-scipy
   pip install .
   python setup.py nosetests
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ setenv =
   TRAVIS = {env:TRAVIS:}
 commands =
   pip install numpy
-  sudo apt-get install python-scipy
   pip install .
   python setup.py nosetests
 


### PR DESCRIPTION
Now normalizing distance for `get_distance` meaning the return values will be changing – I hope not a lot of people use `get_distance`! But I think some breakage is worth in order to get consistency

Also fixed a typo in tests: Equals -> Equal