### PR TITLE
Adjust Go string handling for save()/load()

### DIFF
--- a/src/annoygomodule.i
+++ b/src/annoygomodule.i
@@ -75,8 +75,8 @@
 
 %typemap(in) (const char *)
 %{
-  $1 = (char *)malloc((((_gostring_)$input).n + 1) * sizeof(char));
-  strcpy($1, ((_gostring_)$input).p);
+  $1 = (char *)calloc((((_gostring_)$input).n + 1), sizeof(char));
+  strncpy($1, (((_gostring_)$input).p), ((_gostring_)$input).n);
 %}
 
 %typemap(freearg) (const char *)


### PR DESCRIPTION
On Ubuntu 16.04 with SWIG 3.0.8, the `TestFileHandling` test doesn't pass. I think it fails because the `const char *`s derived from golang's `string`s behave as though they are not null terminated.  

The code in this PR fixed the problem for me. 

Using `calloc` instead of `malloc` to allocate n+1 `char`s worth of memory ensures that a null terminator will be at the end of the string. 

Using `strncpy` copies `n` characters into the allocated space. This preserves the null terminator at the end of the `calloc` block.

@rosmo would you like to test this to make sure it doesn't break anything for you?