### PR TITLE
remove python 2.6 & 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: python
 
 env:
   matrix:
-    - TOXENV=py26
     - TOXENV=py27
-    - TOXENV=py33
     - TOXENV=py34
     - TOXENV=py35
     - TOXENV=go


### PR DESCRIPTION
doesn't build on travis anymore