### PR TITLE
Avoid referencing out of bounds elements

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -596,7 +596,7 @@ protected:
 
     size_t m = nns_dist.size();
     size_t p = n < m ? n : m; // Return this many items
-    std::partial_sort(&nns_dist[0], &nns_dist[p], &nns_dist[m]);
+    std::partial_sort(nns_dist.begin(), nns_dist.begin() + p, nns_dist.end());
     for (size_t i = 0; i < p; i++) {
       if (distances)
         distances->push_back(D::normalized_distance(nns_dist[i].first));


### PR DESCRIPTION
Current way of obtaining bounds for `std::partial_sort` leads to out of bounds assertion error in `std::vector`. This patch replaces `access by index + dereferencing` with getting pointer for 0th element and then advancing it forward. The latter approach is equivalent but safe.