### PR TITLE
Go: fixed getItem call and added a test for it.

### DIFF
--- a/README_GO.rst
+++ b/README_GO.rst
@@ -4,8 +4,11 @@ Install
 To install, you'll need Swig (tested with Swig 3.0.6 on OS X), and then just::
 
   swig -go -intgosize 64 -cgo -c++ src/annoygomodule.i
-  cp src/annoygomodule_wrap.cxx src/annoyindex.go src/annoygomodule.h src/annoylib.h src/kissrandom.h $GOPATH/src/annoyindex
+  mkdir -p $GOPATH/src/annoyindex
+  cp src/annoygomodule_wrap.cxx src/annoyindex.go src/annoygomodule.h src/annoylib.h src/kissrandom.h test/annoy_test.go $GOPATH/src/annoyindex
   cd $GOPATH/src/annoyindex
+  go get -t ...
+  go test
   go build
 
 Background

--- a/src/annoygomodule.h
+++ b/src/annoygomodule.h
@@ -7,6 +7,8 @@ class AnnoyIndex {
  protected:
   ::AnnoyIndexInterface<int32_t, float> *ptr;
 
+  int f;
+
  public:
   ~AnnoyIndex() {
     delete ptr;
@@ -48,8 +50,9 @@ class AnnoyIndex {
   void verbose(bool v) {
     ptr->verbose(v);
   };
-  void getItem(int item, float* v) {
-    ptr->get_item(item, v);
+  void getItem(int item, vector<float> *v) {
+    v->resize(this->f);
+    ptr->get_item(item, &v->front());
   };
 };
 
@@ -58,6 +61,7 @@ class AnnoyIndexAngular : public AnnoyIndex
  public:
   AnnoyIndexAngular(int f) {
     ptr = new ::AnnoyIndex<int32_t, float, ::Angular, ::Kiss64Random>(f);
+    this->f = f;
   }
 };
 
@@ -65,6 +69,7 @@ class AnnoyIndexEuclidean : public AnnoyIndex {
  public:
   AnnoyIndexEuclidean(int f) {
     ptr = new ::AnnoyIndex<int32_t, float, ::Euclidean, ::Kiss64Random>(f);
+    this->f = f;
   }
 };
 

--- a/test/annoy_test.go
+++ b/test/annoy_test.go
@@ -105,6 +105,28 @@ func (suite *AnnoyTestSuite) TestGetNnsByItem() {
      annoyindex.DeleteAnnoyIndexAngular(index)
 }
 
+func (suite *AnnoyTestSuite) TestGetItem() {
+     index := annoyindex.NewAnnoyIndexAngular(3)
+     index.AddItem(0, []float32{2, 1, 0})
+     index.AddItem(1, []float32{1, 2, 0})
+     index.AddItem(2, []float32{0, 0, 1})
+     index.Build(10)
+
+     var result []float32
+
+     index.GetItem(0, &result)
+     assert.Equal(suite.T(), []float32{2, 1, 0}, result)
+
+     index.GetItem(1, &result)
+     assert.Equal(suite.T(), []float32{1, 2, 0}, result)
+
+     index.GetItem(2, &result)
+     assert.Equal(suite.T(), []float32{0, 0, 1}, result)
+
+     annoyindex.DeleteAnnoyIndexAngular(index)
+}
+
+
 func (suite *AnnoyTestSuite) TestGetDistance() {
      index := annoyindex.NewAnnoyIndexAngular(2)
      index.AddItem(0, []float32{0, 1})


### PR DESCRIPTION
The Go language getItem call was not working properly as reported by @AAAton, fixed the call and added a test for it.