### PR TITLE
Add compilation flag to preserve deterministic behaviour

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setup(name='annoy',
         Extension(
             'annoy.annoylib', ['src/annoymodule.cc'],
             depends=['src/annoylib.h', 'src/kissrandom.h', 'src/mman.h'],
-            extra_compile_args=['-O3', '-march=native', '-ffast-math'] + travis_extra_compile_args,
+            extra_compile_args=['-O3', '-march=native',
+                                '-ffast-math', '-fno-associative-math'] + travis_extra_compile_args,
         )
       ],
       long_description=long_description,


### PR DESCRIPTION
This commit fixes possibly non-deterministic building of the index when running on an Intel processor (see issues #190 and #188) by adding compilation flag `-fno-associative-math`.

This could happen even when the seed is set, running the same binary on exactly the same inputs. The culprit is the compiler setting `-ffast-math`, which in turn enables `-funsafe-math-optimizations`, which in turn enables `-fassociative-math`, which allows compiler to treat math operations as associative, so that order of summation in the function `margin` (that computes dot product) can be arbitrary.

It apparently can also be arbitrary between different runs of the same program on the same inputs, [in particular when loops are vectorized:](
http://techdoc.dartmouth.edu/discovery/wp-content/uploads/FP_Consistency_12.pdf)

> Slightly different results were observed when re-running the same (non-threaded)
> binary on the same data on the same processor.
> This was caused by variations in the starting address and alignment of the global
> stack, resulting from events external to the program. The resulting change in local
> stack alignment led to changes in which loop iterations were assigned to the loop
> prologue or epilogue, and which to the vectorized loop kernel. This in turn led to
> changes in the order of operations for vectorized reductions (i.e., reassociation).

("slightly different" in case of the `margin` function  can be enough to build the tree in a different way; the result is used right after that in the `side` function, which takes a binary decision)

Enabling back the computation order guarantee does not seem to visibly affect performance, but it brings back reproducibility, which looks like a fair tradeoff.

Note that in my case (Intel i7-4790K, Linux Mint 18, annoy v.1.8.3) the existing unit test `SeedTest` already intermittently failed (once in 10-ish runs). Bumping the number of vectors to 500000 and number of trees to 50 made test failure almost certain.