### PR TITLE
Adding support for binary vectors under hamming distance

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -699,7 +699,7 @@ protected:
       search_k = n * _roots.size(); // slightly arbitrary default value
 
     for (size_t i = 0; i < _roots.size(); i++) {
-      q.push(make_pair(Distance::pq_initial_value(), _roots[i]));
+      q.push(make_pair(Distance::template pq_initial_value<T>(), _roots[i]));
     }
 
     vector<S> nns;

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -238,7 +238,7 @@ struct Hamming {
     return margin(n, y, f);
   }
   static inline int chunkcount(int f) {
-    return f / chunksize() + 1;
+    return (f + chunksize() - 1) / chunksize();
   }
   template<typename S, typename T = int64_t, typename Random>
   static inline void create_split(const vector<Node<S, T>*>& nodes, int f, Random& random, Node<S, T>* n) {

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -237,42 +237,43 @@ struct Hamming {
   static inline bool side(const Node<S, T>* n, const T* y, int f, Random& random) {
     return margin(n, y, f);
   }
-	static inline int chunkcount(int f) {
-		return f / chunksize() + 1;
-	}
-	template<typename S, typename T = int64_t, typename Random>
-	static inline void create_split(const vector<Node<S, T>*>& nodes, int f, Random& random, Node<S, T>* n) {
-		size_t cur_split = 0, cur_size = 0;
-		int i = 0;
-		for (; i < max_iterations; i++) {
-			n->v[0] = random.index(f);
-			cur_size = 0;
-			for (auto& nd: nodes) {
-				if (margin(n, nd->v, f)) {
-					cur_size++;
-				}
-			}
-			if (cur_size > 0 && cur_size < nodes.size()) {
-				break;
-			}
-		}
-		// brute-force search for splitting coordinate
-		if (i == max_iterations) {
-			int j = 0;
-			for (; j < f; j++) {
-				n->v[0] = j;
-				cur_size = 0;
-				for (auto& nd: nodes) {
-					if (margin(n, nd->v, f)) {
-						cur_size++;
-					}
-				}
-				if (cur_size > 0 && cur_size < nodes.size()) {
-					break;
-				}
-			}
-		}
-	}
+  static inline int chunkcount(int f) {
+    return f / chunksize() + 1;
+  }
+  template<typename S, typename T = int64_t, typename Random>
+  static inline void create_split(const vector<Node<S, T>*>& nodes, int f, Random& random, Node<S, T>* n) {
+    size_t cur_split = 0, cur_size = 0;
+    int i = 0;
+    for (; i < max_iterations; i++) {
+      // choose random position to split at
+      n->v[0] = random.index(f);
+      cur_size = 0;
+      for (auto& nd: nodes) {
+        if (margin(n, nd->v, f)) {
+          cur_size++;
+        }
+      }
+      if (cur_size > 0 && cur_size < nodes.size()) {
+        break;
+      }
+    }
+    // brute-force search for splitting coordinate
+    if (i == max_iterations) {
+      int j = 0;
+      for (; j < f; j++) {
+        n->v[0] = j;
+        cur_size = 0;
+        for (auto& nd: nodes) {
+          if (margin(n, nd->v, f)) {
+            cur_size++;
+          }
+        }
+        if (cur_size > 0 && cur_size < nodes.size()) {
+          break;
+        }
+      }
+    }
+  }
   template<typename T = int64_t>
   static inline T normalized_distance(T distance) {
     return distance;


### PR DESCRIPTION
## Purpose
This PR adds support for binary vectors (stored in 64-bit chunks) under Hamming distance. Instead of random projections, it splits by projecting a vector to a single bit at a random position, which is known to be optimal in the locality-sensitive hashing world. Distance computations are done xor'ing and counting ones in the result using built-in `popcount` intrinsics.

These changes made some refactoring necessary in the query code w.r.t. the PQ. The initial value and the priority that is associated with an element is now configurable from within the distance measure struct. The compiler was able to inline these calls on my setup, yielding identical code/performance. 

## Performance

Below some screenshots comparing the performance. 
![screen shot 2017-10-25 at 14 47 02](https://user-images.githubusercontent.com/6311646/31999777-d383f512-b994-11e7-970c-c8da9d4c1459.png)

This is from a binary version of the SIFT dataset. Both euclidean and hamming distance versions allow to get recall close to 1, hamming distance is a bit faster. Original version from spotify/annoy as fast as the updated version with the changed PQ interface.

![screen shot 2017-10-25 at 14 47 12](https://user-images.githubusercontent.com/6311646/31999776-d3539b9c-b994-11e7-9398-b40b1aee67b2.png)

This is from a binary version of the NYtimes dataset. Projecting to a single bit works much better quality wise.

## Bottom line

I don't know much about the wrappers to annoy. The representation of data points from the python side would be what `numpy.packbits` with `dtype=uint64` produces.

Looking forward to hearing your thoughts on this PR. 