### PR TITLE
Adding Python 2.7 support for Windows

### DIFF
--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -17,7 +17,11 @@
 #include "Python.h"
 #include "structmember.h"
 #include <exception>
+#if defined(_MSC_VER) && _MSC_VER == 1500
+typedef signed __int32    int32_t;
+#else
 #include <stdint.h>
+#endif
 
 
 #if PY_MAJOR_VERSION >= 3


### PR DESCRIPTION
Added some compiler checks for MSVC 2008 and 'reverted' #3 in the case of the MSVC 2008 compiler (and for some reason when debugging with any MSVC compiler, std::copy isn't working).