### PR TITLE
Hamming distance (continued from #231)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,8 @@ Annoy was built by `Erik Bernhardsson <http://www.erikbern.com>`__ in a couple o
 Summary of features
 -------------------
 
-* Euclidean distance, Manhattan distance or cosine distance, where cosine distance uses Euclidean distance of normalized vectors = sqrt(2-2*cos(u, v))
+* `Euclidean distance <https://en.wikipedia.org/wiki/Euclidean_distance>`__, `Manhattan distance <https://en.wikipedia.org/wiki/Taxicab_geometry>`__, `cosine distance <https://en.wikipedia.org/wiki/Cosine_similarity>`__, or `Hamming distance <https://en.wikipedia.org/wiki/Hamming_distance>`__
+* Cosine distance is equivalent to Euclidean distance of normalized vectors = sqrt(2-2*cos(u, v))
 * Works better if you don't have too many dimensions (like <100) but seems to perform surprisingly well even up to 1,000 dimensions
 * Small memory usage
 * Lets you share memory between multiple processes
@@ -74,7 +75,7 @@ Right now it only accepts integers as identifiers for items. Note that it will a
 Full Python API
 ---------------
 
-* ``AnnoyIndex(f, metric='angular')`` returns a new index that's read-write and stores vector of ``f`` dimensions. Metric can be ``"angular"``, ``"euclidean"`` or ``"manhattan"``.
+* ``AnnoyIndex(f, metric='angular')`` returns a new index that's read-write and stores vector of ``f`` dimensions. Metric can be ``"angular"``, ``"euclidean"``, ``"manhattan"``, or ``"hamming"``.
 * ``a.add_item(i, v)`` adds item ``i`` (any nonnegative integer) with vector ``v``. Note that it will allocate memory for ``max(i)+1`` items.
 * ``a.build(n_trees)`` builds a forest of ``n_trees`` trees. More trees gives higher precision when querying. After calling ``build``, no more items can be added.
 * ``a.save(fn)`` saves the index to disk.
@@ -111,16 +112,18 @@ Using `random projections <http://en.wikipedia.org/wiki/Locality-sensitive_hashi
 
 We do this k times so that we get a forest of trees. k has to be tuned to your need, by looking at what tradeoff you have between precision and performance.
 
+Hamming distance (contributed by `Martin Aumüller <https://github.com/maumueller>`__) packs the data into 64-bit integers under the hood and uses built-in bit count primitives so it could be quite fast. All splits are axis-aligned.
+
 More info
 ---------
 
-* `Dirk Eddelbuettel <http://dirk.eddelbuettel.com/>`__ provides an `R version of Annoy <http://dirk.eddelbuettel.com/code/rcpp.annoy.html>`__.
-* `Andy Sloane <http://www.a1k0n.net/>`__ provides a `Java version of Annoy <https://github.com/spotify/annoy-java>`__ although currently limited to cosine and read-only.
-* Pishen Tsai provides a `Scala wrapper of Annoy <https://github.com/pishen/annoy4s>`__ which uses JNA to call the C++ library of Annoy.
-* There is `experimental support for Go <https://github.com/spotify/annoy/blob/master/README_GO.rst>`__ provided by Taneli Leppä.
-* Boris Nagaev wrote `Lua bindings <https://github.com/spotify/annoy/blob/master/README_Lua.md>`__.
-* During part of Spotify Hack Week 2016 (and a bit afterward), Jim Kang wrote `Node bindings <https://github.com/jimkang/annoy-node>`__ for Annoy.
-* Min-Seok Kim built a `Scala version <https://github.com/mskimm/ann4s>`__ of Annoy.
+* `Dirk Eddelbuettel <https://github.com/eddelbuettel>`__ provides an `R version of Annoy <http://dirk.eddelbuettel.com/code/rcpp.annoy.html>`__.
+* `Andy Sloane <https://github.com/a1k0n>`__ provides a `Java version of Annoy <https://github.com/spotify/annoy-java>`__ although currently limited to cosine and read-only.
+* `Pishen Tsai <https://github.com/pishen>`__ provides a `Scala wrapper of Annoy <https://github.com/pishen/annoy4s>`__ which uses JNA to call the C++ library of Annoy.
+* There is `experimental support for Go <https://github.com/spotify/annoy/blob/master/README_GO.rst>`__ provided by `Taneli Leppä <https://github.com/rosmo>`__.
+* `Boris Nagaev <https://github.com/starius>`__ wrote `Lua bindings <https://github.com/spotify/annoy/blob/master/README_Lua.md>`__.
+* During part of Spotify Hack Week 2016 (and a bit afterward), `Jim Kang <https://github.com/jimkang>`__ wrote `Node bindings <https://github.com/jimkang/annoy-node>`__ for Annoy.
+* `Min-Seok Kim <https://github.com/mskimm>`__ built a `Scala version <https://github.com/mskimm/ann4s>`__ of Annoy.
 * `Presentation from New York Machine Learning meetup <http://www.slideshare.net/erikbern/approximate-nearest-neighbor-methods-and-vector-models-nyc-ml-meetup>`__ about Annoy
 * Radim Řehůřek's blog posts comparing Annoy to a couple of other similar Python libraries: `Intro <http://radimrehurek.com/2013/11/performance-shootout-of-nearest-neighbours-intro/>`__, `Contestants <http://radimrehurek.com/2013/12/performance-shootout-of-nearest-neighbours-contestants/>`__, `Querying <http://radimrehurek.com/2014/01/performance-shootout-of-nearest-neighbours-querying/>`__
 * `ann-benchmarks <https://github.com/erikbern/ann-benchmarks>`__ is a benchmark for several approximate nearest neighbor libraries. Annoy seems to be fairly competitive, especially at higher precisions:
@@ -135,7 +138,7 @@ Source code
 
 It's all written in C++ with a handful of ugly optimizations for performance and memory usage. You have been warned :)
 
-The code should support Windows, thanks to `thirdwing <https://github.com/thirdwing>`__.
+The code should support Windows, thanks to `Qiang Kou <https://github.com/thirdwing>`__ and `Timothy Riley <https://github.com/tjrileywisc>`__.
 
 To run the tests, execute `python setup.py nosetests`. The test suite includes a big real world dataset that is downloaded from the internet, so it will take a few minutes to execute.
 

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -247,8 +247,9 @@ struct Hamming {
   }
   template<typename S, typename T>
   static inline bool margin(const Node<S, T>* n, const T* y, int f) {
-    T chunk = n->v[0] / 64;
-    return (y[chunk] & (static_cast<T>(1) << (64 - 1 - (n->v[0] % 64)))) != 0;
+    static const size_t n_bits = sizeof(T) * 8;
+    T chunk = n->v[0] / n_bits;
+    return (y[chunk] & (static_cast<T>(1) << (n_bits - 1 - (n->v[0] % n_bits)))) != 0;
   }
   template<typename S, typename T, typename Random>
   static inline bool side(const Node<S, T>* n, const T* y, int f, Random& random) {

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -62,9 +62,9 @@ typedef signed __int32    int32_t;
 
 
 #ifndef _MSC_VER
-#define uint64_popcount __builtin_popcountll
+#define popcount __builtin_popcountll
 #else
-#define uint64_popcount __popcnt64
+#define popcount __popcnt64
 #endif
 
 
@@ -219,7 +219,7 @@ struct Angular {
 
 struct Hamming {
 
-  template<typename S, typename T = uint64_t>
+  template<typename S, typename T>
   struct ANNOY_NODE_ATTRIBUTE Node {
     S n_descendants;
     S children[2];
@@ -228,43 +228,42 @@ struct Hamming {
 
   static const size_t max_iterations = 20;
 
-  template<typename T = uint64_t>
+  template<typename T>
   static inline T pq_distance(T distance, T margin, int child_nr) {
     return distance - (margin != child_nr);
   }
 
-  template<typename T = uint64_t>
+  template<typename T>
   static inline T pq_initial_value() {
     return 0;
   }
-  template<typename T = uint64_t>
+  template<typename T>
   static inline T distance(const T* x, const T* y, int f) {
     size_t dist = 0;
-    for (size_t i = 0; i < f; i++)
-    {
-      dist += uint64_popcount(x[i] ^ y[i]);
+    for (size_t i = 0; i < f; i++) {
+      dist += popcount(x[i] ^ y[i]);
     }
     return dist;
   }
-  template<typename S, typename T = uint64_t>
+  template<typename S, typename T>
   static inline bool margin(const Node<S, T>* n, const T* y, int f) {
     T chunk = n->v[0] / 64;
     return (y[chunk] & (static_cast<T>(1) << (64 - 1 - (n->v[0] % 64)))) != 0;
   }
-  template<typename S, typename T = uint64_t, typename Random>
+  template<typename S, typename T, typename Random>
   static inline bool side(const Node<S, T>* n, const T* y, int f, Random& random) {
     return margin(n, y, f);
   }
-  template<typename S, typename T = uint64_t, typename Random>
+  template<typename S, typename T, typename Random>
   static inline void create_split(const vector<Node<S, T>*>& nodes, int f, Random& random, Node<S, T>* n) {
-    size_t cur_split = 0, cur_size = 0;
+    size_t cur_size = 0;
     int i = 0;
     for (; i < max_iterations; i++) {
       // choose random position to split at
       n->v[0] = random.index(f);
       cur_size = 0;
-      for (auto& nd: nodes) {
-        if (margin(n, nd->v, f)) {
+      for (typename vector<Node<S, T>*>::const_iterator it = nodes.begin(); it != nodes.end(); ++it) {
+        if (margin(n, (*it)->v, f)) {
           cur_size++;
         }
       }
@@ -278,8 +277,8 @@ struct Hamming {
       for (; j < f; j++) {
         n->v[0] = j;
         cur_size = 0;
-        for (auto& nd: nodes) {
-          if (margin(n, nd->v, f)) {
+	for (typename vector<Node<S, T>*>::const_iterator it = nodes.begin(); it != nodes.end(); ++it) {
+          if (margin(n, (*it)->v, f)) {
             cur_size++;
           }
         }
@@ -289,7 +288,7 @@ struct Hamming {
       }
     }
   }
-  template<typename T = uint64_t>
+  template<typename T>
   static inline T normalized_distance(T distance) {
     return distance;
   }

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -61,7 +61,11 @@ typedef signed __int32    int32_t;
 #endif
 
 
-
+#ifndef _MSC_VER
+#define uint64_popcount __builtin_popcountll
+#else
+#define uint64_popcount __popcnt64
+#endif
 
 
 #ifndef ANNOY_NODE_ATTRIBUTE
@@ -238,7 +242,7 @@ struct Hamming {
     size_t dist = 0;
     for (size_t i = 0; i < f; i++)
     {
-      dist += __builtin_popcountll(x[i] ^ y[i]);
+      dist += uint64_popcount(x[i] ^ y[i]);
     }
     return dist;
   }

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -219,7 +219,7 @@ struct Angular {
 
 struct Hamming {
 
-  template<typename S, typename T = int64_t>
+  template<typename S, typename T = uint64_t>
   struct ANNOY_NODE_ATTRIBUTE Node {
     S n_descendants;
     S children[2];
@@ -228,16 +228,16 @@ struct Hamming {
 
   static const size_t max_iterations = 20;
 
-  template<typename T = int64_t>
+  template<typename T = uint64_t>
   static inline T pq_distance(T distance, T margin, int child_nr) {
     return distance - (margin != child_nr);
   }
 
-  template<typename T = int64_t>
+  template<typename T = uint64_t>
   static inline T pq_initial_value() {
     return 0;
   }
-  template<typename T = int64_t>
+  template<typename T = uint64_t>
   static inline T distance(const T* x, const T* y, int f) {
     size_t dist = 0;
     for (size_t i = 0; i < f; i++)
@@ -246,16 +246,16 @@ struct Hamming {
     }
     return dist;
   }
-  template<typename S, typename T = int64_t>
+  template<typename S, typename T = uint64_t>
   static inline bool margin(const Node<S, T>* n, const T* y, int f) {
     T chunk = n->v[0] / 64;
     return (y[chunk] & (static_cast<T>(1) << (64 - 1 - (n->v[0] % 64)))) != 0;
   }
-  template<typename S, typename T = int64_t, typename Random>
+  template<typename S, typename T = uint64_t, typename Random>
   static inline bool side(const Node<S, T>* n, const T* y, int f, Random& random) {
     return margin(n, y, f);
   }
-  template<typename S, typename T = int64_t, typename Random>
+  template<typename S, typename T = uint64_t, typename Random>
   static inline void create_split(const vector<Node<S, T>*>& nodes, int f, Random& random, Node<S, T>* n) {
     size_t cur_split = 0, cur_size = 0;
     int i = 0;
@@ -289,7 +289,7 @@ struct Hamming {
       }
     }
   }
-  template<typename T = int64_t>
+  template<typename T = uint64_t>
   static inline T normalized_distance(T distance) {
     return distance;
   }

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -49,7 +49,7 @@ private:
   void _pack(const float* src, uint64_t* dst) {
     for (int32_t i = 0; i < _f_internal; i++) {
       dst[i] = 0;
-      for (int32_t j = 0; j < 64; j++) {
+      for (int32_t j = 0; j < 64 && i*64+j < _f_external; j++) {
 	dst[i] |= (uint64_t)(src[i * 64 + j] > 0.5) << j;
       }
     }

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -41,25 +41,59 @@ template class AnnoyIndexInterface<int32_t, float>;
 
 class HammingWrapper : public AnnoyIndexInterface<int32_t, float> {
   // Wrapper class for Hamming distance, using composition.
-  // This translates binary (float) vectors into packed int64_t vectors.
+  // This translates binary (float) vectors into packed uint64_t vectors.
   // This is questionable from a performance point of view. Should reconsider this solution.
 private:
-  AnnoyIndex<int64_t, int64_t, Hamming, Kiss64Random> _index;
+  AnnoyIndex<int32_t, uint64_t, Hamming, Kiss64Random> _index;
+  int32_t _f_external, _f_internal;
+  void _pack(const float* src, uint64_t* dst) {
+    for (int32_t i = 0; i < _f_internal; i++) {
+      dst[i] = 0;
+      for (int32_t j = 0; j < 64; j++) {
+	dst[i] |= (uint64_t)(src[i * 64 + j] > 0.5) << j;
+      }
+    }
+  };
+  void _unpack(const uint64_t* src, float* dst) {
+    for (int32_t i = 0; i < _f_external; i++) {
+      dst[i] = (src[i / 64] >> (i % 64)) & 1;
+    }
+  };
 public:
-  HammingWrapper(int f) : _index((f + 63) / 64) {};
-  void add_item(int32_t item, const float* w) {};
-  void build(int q) {_index.build(q);};
-  void unbuild() {_index.unbuild();};
-  bool save(const char* filename) {return _index.save(filename);};
-  void unload() {_index.unload();};
-  bool load(const char* filename) {return _index.load(filename);};
-  float get_distance(int32_t i, int32_t j) {return _index.get_distance(i, j);};
-  void get_nns_by_item(int32_t item, size_t n, size_t search_k, vector<int32_t>* result, vector<float>* distances) {};
-  void get_nns_by_vector(const float* w, size_t n, size_t search_k, vector<int32_t>* result, vector<float>* distances) {};
-  int32_t get_n_items() {return _index.get_n_items();};
-  void verbose(bool v) {_index.verbose(v);};
-  void get_item(int32_t item, float* v) {};
-  void set_seed(int q) {_index.set_seed(q);};
+  HammingWrapper(int f) : _f_external(f), _f_internal((f + 63) / 64), _index((f + 63) / 64) {};
+  void add_item(int32_t item, const float* w) {
+    vector<uint64_t> w_internal(_f_internal, 0);
+    _pack(w, &w_internal[0]);
+    for (int i = 0; i < _f_internal; i++) {
+    }
+    _index.add_item(item, &w_internal[0]);
+  };
+  void build(int q) { _index.build(q); };
+  void unbuild() { _index.unbuild(); };
+  bool save(const char* filename) { return _index.save(filename); };
+  void unload() { _index.unload(); };
+  bool load(const char* filename) { return _index.load(filename); };
+  float get_distance(int32_t i, int32_t j) { return _index.get_distance(i, j); };
+  void get_nns_by_item(int32_t item, size_t n, size_t search_k, vector<int32_t>* result, vector<float>* distances) {
+    vector<uint64_t> distances_internal;
+    _index.get_nns_by_item(item, n, search_k, result, &distances_internal);
+    std::copy(distances_internal.begin(), distances_internal.end(), distances->begin());
+  };
+  void get_nns_by_vector(const float* w, size_t n, size_t search_k, vector<int32_t>* result, vector<float>* distances) {
+    vector<uint64_t> distances_internal;
+    vector<uint64_t> w_internal(_f_internal, 0);
+    _pack(w, &w_internal[0]);
+    _index.get_nns_by_vector(&w_internal[0], n, search_k, result, &distances_internal);
+    std::copy(distances_internal.begin(), distances_internal.end(), distances->begin());
+  };
+  int32_t get_n_items() { return _index.get_n_items(); };
+  void verbose(bool v) { _index.verbose(v); };
+  void get_item(int32_t item, float* v) {
+    vector<uint64_t> v_internal(_f_internal, 0);
+    _index.get_item(item, &v_internal[0]);
+    _unpack(&v_internal[0], v);
+  };
+  void set_seed(int q) { _index.set_seed(q); };
 };
 
 // annoy python object

--- a/test/hamming_index_test.py
+++ b/test/hamming_index_test.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2013 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import numpy
+import random
+from common import TestCase
+from annoy import AnnoyIndex
+
+
+class HammingIndexTest(TestCase):
+    def test_create_index(self):
+        f = 3
+        i = AnnoyIndex(3, 'hamming')

--- a/test/hamming_index_test.py
+++ b/test/hamming_index_test.py
@@ -24,7 +24,6 @@ class HammingIndexTest(TestCase):
         i = AnnoyIndex(f, 'hamming')
         u = numpy.random.binomial(1, 0.5, f)
         v = numpy.random.binomial(1, 0.5, f)
-        print(u)
         i.add_item(0, u)
         i.add_item(1, v)
         u2 = i.get_item_vector(0)

--- a/test/hamming_index_test.py
+++ b/test/hamming_index_test.py
@@ -34,3 +34,18 @@ class HammingIndexTest(TestCase):
         self.assertAlmostEqual(i.get_distance(1, 1), 0.0)
         self.assertAlmostEqual(i.get_distance(0, 1), numpy.dot(u - v, u - v))
         self.assertAlmostEqual(i.get_distance(1, 0), numpy.dot(u - v, u - v))
+
+    def test_basic_nns(self):
+        f = 100
+        i = AnnoyIndex(f, 'hamming')
+        u = numpy.random.binomial(1, 0.5, f)
+        v = numpy.random.binomial(1, 0.5, f)
+        i.add_item(0, u)
+        i.add_item(1, v)
+        i.build(10)
+        self.assertEquals(i.get_nns_by_item(0, 99), [0, 1])
+        self.assertEquals(i.get_nns_by_item(1, 99), [1, 0])
+        rs, ds = i.get_nns_by_item(0, 99, include_distances=True)
+        self.assertEquals(rs, [0, 1])
+        self.assertAlmostEqual(ds[0], 0)
+        self.assertAlmostEqual(ds[1], numpy.dot(u-v, u-v))

--- a/test/hamming_index_test.py
+++ b/test/hamming_index_test.py
@@ -82,4 +82,4 @@ class HammingIndexTest(TestCase):
             rs, ds = i.get_nns_by_vector(numpy.random.binomial(1, 0.5, f), 1, search_k=1000, include_distances=True)
             dists.append(ds[0])
         avg_dist = 1.0 * sum(dists) / len(dists)
-        self.assertLessThan(avg_dist, 0.42)
+        self.assertLessEqual(avg_dist, 0.42)

--- a/test/hamming_index_test.py
+++ b/test/hamming_index_test.py
@@ -19,6 +19,19 @@ from annoy import AnnoyIndex
 
 
 class HammingIndexTest(TestCase):
-    def test_create_index(self):
-        f = 3
-        i = AnnoyIndex(3, 'hamming')
+    def test_basic_conversion(self):
+        f = 100
+        i = AnnoyIndex(f, 'hamming')
+        u = numpy.random.binomial(1, 0.5, f)
+        v = numpy.random.binomial(1, 0.5, f)
+        print(u)
+        i.add_item(0, u)
+        i.add_item(1, v)
+        u2 = i.get_item_vector(0)
+        v2 = i.get_item_vector(1)
+        self.assertAlmostEqual(numpy.dot(u - u2, u - u2), 0.0)
+        self.assertAlmostEqual(numpy.dot(v - v2, v - v2), 0.0)
+        self.assertAlmostEqual(i.get_distance(0, 0), 0.0)
+        self.assertAlmostEqual(i.get_distance(1, 1), 0.0)
+        self.assertAlmostEqual(i.get_distance(0, 1), numpy.dot(u - v, u - v))
+        self.assertAlmostEqual(i.get_distance(1, 0), numpy.dot(u - v, u - v))


### PR DESCRIPTION
This implements the Python binding for Hamming distance – based on #231 by @maumueller 

To make it a bit simpler:
1. I removed all the "chunking" from the C++ part. Inside the C++ module, each `uint64_t` item is considered a "dimension".
2. I kept the Python interface consistent and avoided a bunch of extra code by assuming it's passed an array of floats. This creates a few extra unnecessary copies of data and a bloated storage in Python. I think in the grand scheme of things, it's probably not substantial.
3. Removed some C++11 features, think support for things like `auto` is still a bit unreliable.