### PR TITLE
Manually vectorize distance functions to improve performance

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -254,18 +254,18 @@ struct Angular {
       __m256 dot = _mm256_setzero_ps();
       for (; i > 7; i -= 8) {
         dot = _mm256_add_ps(dot, _mm256_mul_ps(_mm256_loadu_ps(x), _mm256_loadu_ps(y)));
-          x += 8;
-          y += 8;
-        }
-        // Sum all floats in dot register.
-        result = hsum256_ps_avx(dot);
+        x += 8;
+        y += 8;
       }
-      // Don't forget the remaining values.
-      for (; i > 0; i--) {
-        result += *x * *y;
-        x++;
-        y++;
-      }
+      // Sum all floats in dot register.
+      result = hsum256_ps_avx(dot);
+    }
+    // Don't forget the remaining values.
+    for (; i > 0; i--) {
+      result += *x * *y;
+      x++;
+      y++;
+    }
     return result;
   }
 #endif

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -613,6 +613,32 @@ struct Manhattan : Minkowski{
       d += fabs((*x) - (*y));
     return d;
   }
+#ifdef USE_AVX
+  static inline float distance(const float* x, const float* y, int f) {
+    float result = 0;
+    int i = f;
+    if (f > 7) {
+      __m256 manhattan = _mm256_setzero_ps();
+      __m256 minus_zero = _mm256_set1_ps(-0.0f);
+      for (; i > 7; i -= 8) {
+        const __m256 x_minus_y = _mm256_sub_ps(_mm256_loadu_ps(x), _mm256_loadu_ps(y));
+        const __m256 distance = _mm256_andnot_ps(minus_zero, x_minus_y); // Absolute value of x_minus_y (forces sign bit to zero)
+        manhattan = _mm256_add_ps(manhattan, distance);
+        x += 8;
+        y += 8;
+      }
+      // Sum all floats in manhattan register.
+      result = hsum256_ps_avx(manhattan);
+    }
+    // Don't forget the remaining values.
+    for (; i > 0; i--) {
+      result += fabsf(*x - *y);
+      x++;
+      y++;
+    }
+    return result;
+  }
+#endif
   template<typename S, typename T, typename Random>
   static inline void create_split(const vector<Node<S, T>*>& nodes, int f, Random& random, Node<S, T>* n) {
     vector<T> best_iv(f, 0), best_jv(f, 0);


### PR DESCRIPTION
For a start I vectorized the euclidian distance with AVX intrinsics. I wanted to make sure, that there is an actual improvement. I created a super [basic benchmark](https://gist.github.com/ReneHollander/4ca884ceb1537f013aa8d0f868e9b844) which improved the index build time with `2*f` trees from roughly 45 seconds to 35 seconds and search time from 13ms to 9ms (Windows 10 Subsystem for Linux on an i7 4770K overclocked to 4GHz, the benchmark also contains some results). I only tested with random high dimensional data (96 and 100 dimensions and 100000 features)

With that said, is there interest in optimizing other distance functions and other functions in general? (I am no expert and there is the possibility, that there are even better solutions, but for a start it could help)