### PR TITLE
Fixes to Hamming distance.

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -336,12 +336,12 @@ struct Hamming {
 
   template<typename T>
   static inline T pq_distance(T distance, T margin, int child_nr) {
-    return distance + (margin == (unsigned int) child_nr);
+    return distance - (margin != (unsigned int) child_nr);
   }
 
   template<typename T>
   static inline T pq_initial_value() {
-    return 0;
+    return numeric_limits<T>::max();
   }
   template<typename S, typename T>
   static inline T distance(const Node<S, T>* x, const Node<S, T>* y, int f) {

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -336,7 +336,7 @@ struct Hamming {
 
   template<typename T>
   static inline T pq_distance(T distance, T margin, int child_nr) {
-    return distance - (margin != (unsigned int) child_nr);
+    return distance + (margin == (unsigned int) child_nr);
   }
 
   template<typename T>
@@ -365,9 +365,10 @@ struct Hamming {
   static inline void create_split(const vector<Node<S, T>*>& nodes, int f, size_t s, Random& random, Node<S, T>* n) {
     size_t cur_size = 0;
     size_t i = 0;
+    int dim = f * 8 * sizeof(T);
     for (; i < max_iterations; i++) {
       // choose random position to split at
-      n->v[0] = random.index(f);
+      n->v[0] = random.index(dim);
       cur_size = 0;
       for (typename vector<Node<S, T>*>::const_iterator it = nodes.begin(); it != nodes.end(); ++it) {
         if (margin(n, (*it)->v, f)) {
@@ -381,7 +382,7 @@ struct Hamming {
     // brute-force search for splitting coordinate
     if (i == max_iterations) {
       int j = 0;
-      for (; j < f; j++) {
+      for (; j < dim; j++) {
         n->v[0] = j;
         cur_size = 0;
 	for (typename vector<Node<S, T>*>::const_iterator it = nodes.begin(); it != nodes.end(); ++it) {


### PR DESCRIPTION
This fixes some issues that have been introduced during #243. First, since `f` is in `uint64_t` chunks, we have to manually compute the dimension of the vectors to choose a correct index for splitting. Next, the `pq_distance` computation assumed integer, not unsigned integer. Changed it to work for unsigned integers. 