### PR TITLE
re-split when encounter empty plane

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 2.8)
+PROJECT(FeatureSearch)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_SKIP_RPATH ON)
+set(CMAKE_MACOSX_RPATH 0)
+if (POLICY CMP0054)
+    cmake_policy(SET CMP0054 NEW)
+endif()
+
+include_directories (
+    ${PROJECT_SOURCE_DIR}/../src
+)
+
+ADD_EXECUTABLE(
+    precision_test
+    precision_test.cpp
+    ../src/annoylib.h
+)
+
+TARGET_LINK_LIBRARIES(
+    precision_test
+    ${OpenCV_LIBS}
+)

--- a/examples/precision_test.cpp
+++ b/examples/precision_test.cpp
@@ -45,7 +45,8 @@ int precision(int f=40, int n=1000000){
 
 	}
 	std::cout << std::endl;
-	std::cout << "Building index num_trees = 2 * num_features ...";
+	std::cout << "Building index num_trees = 2 * num_features ..." << std::endl;
+	t.verbose(true);
 	t_start = std::chrono::high_resolution_clock::now();
 	t.build(2 * f);
 	t_end = std::chrono::high_resolution_clock::now();

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -806,7 +806,7 @@ protected:
       children_indices[0].clear();
       children_indices[1].clear();
 
-      // Set the vector to 0.0
+      // try find new split for better hyperplane
       D::create_split(children, _f, _s, _random, m);
 
       for (size_t i = 0; i < indices.size(); i++) {

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -807,13 +807,15 @@ protected:
       children_indices[1].clear();
 
       // Set the vector to 0.0
-      for (int z = 0; z < _f; z++)
-        m->v[z] = 0.0;
+      D::create_split(children, _f, _s, _random, m);
 
       for (size_t i = 0; i < indices.size(); i++) {
         S j = indices[i];
-        // Just randomize...
-        children_indices[_random.flip()].push_back(j);
+        Node *n = _get(j);
+        if (n) {
+          bool side = D::side(m, n->v, _f, _random);
+          children_indices[side].push_back(j);
+        }
       }
     }
 


### PR DESCRIPTION
hi, @erikbern,
 Is that make sense to re-split hyperplane when create_split leads to all children nodes to single sub plane(i.e. `children_indices[0].size() == 0 || children_indices[1].size() == 0`)?