### PR TITLE
change metric in create_split

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -292,9 +292,11 @@ struct Angular {
     Node<S, T>* p = (Node<S, T>*)malloc(s); // TODO: avoid
     Node<S, T>* q = (Node<S, T>*)malloc(s); // TODO: avoid
     two_means<T, Random, Angular, Node<S, T> >(nodes, f, random, true, p, q);
+    normalize(p->v, f);
+    normalize(q->v, f);
     for (int z = 0; z < f; z++)
       n->v[z] = p->v[z] - q->v[z];
-    normalize(n->v, f);
+    // normalize(n->v, f);
     free(p);
     free(q);
   }


### PR DESCRIPTION
correct me if I'm wrong. 

I think in create_split() is used to find two mean points p,q. and we will split the nodes later with method the compare the distance difference between p,node[i] and q,node[i] for each node in current hyperplane.

and we will use dot(n, node[i]) for quick calculation. 
because   n=p-q, so
dot(n, node[i]) = dot(p, node[i]) - dot(q, node[i])

if we can keep p and q are normalized. dot(n, node[i]) may be better for representing the node i is near p or q in Angular metric.