### PR TITLE
Add dot product as a distance metric.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ We do this k times so that we get a forest of trees. k has to be tuned to your n
 
 Hamming distance (contributed by `Martin Aumüller <https://github.com/maumueller>`__) packs the data into 64-bit integers under the hood and uses built-in bit count primitives so it could be quite fast. All splits are axis-aligned.
 
-Dot Product distance (contributed by `Peter Sobot <https://github.com/psobot>`__) reduces the provided vectors from dot (or "inner-product") space to a more query-friendly cosine space using [a method by Bachrach et. al., at Microsoft Research, published in 2014](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/XboxInnerProduct.pdf).
+Dot Product distance (contributed by `Peter Sobot <https://github.com/psobot>`__) reduces the provided vectors from dot (or "inner-product") space to a more query-friendly cosine space using [a method by Bachrach et al., at Microsoft Research, published in 2014](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/XboxInnerProduct.pdf).
 
 More info
 ---------

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Annoy was built by `Erik Bernhardsson <http://www.erikbern.com>`__ in a couple o
 Summary of features
 -------------------
 
-* `Euclidean distance <https://en.wikipedia.org/wiki/Euclidean_distance>`__, `Manhattan distance <https://en.wikipedia.org/wiki/Taxicab_geometry>`__, `cosine distance <https://en.wikipedia.org/wiki/Cosine_similarity>`__, or `Hamming distance <https://en.wikipedia.org/wiki/Hamming_distance>`__
+* `Euclidean distance <https://en.wikipedia.org/wiki/Euclidean_distance>`__, `Manhattan distance <https://en.wikipedia.org/wiki/Taxicab_geometry>`__, `cosine distance <https://en.wikipedia.org/wiki/Cosine_similarity>`__, `Hamming distance <https://en.wikipedia.org/wiki/Hamming_distance>`__, or `Dot (Inner) Product distance <https://en.wikipedia.org/wiki/Dot_product>`__
 * Cosine distance is equivalent to Euclidean distance of normalized vectors = sqrt(2-2*cos(u, v))
 * Works better if you don't have too many dimensions (like <100) but seems to perform surprisingly well even up to 1,000 dimensions
 * Small memory usage
@@ -75,7 +75,7 @@ Right now it only accepts integers as identifiers for items. Note that it will a
 Full Python API
 ---------------
 
-* ``AnnoyIndex(f, metric='angular')`` returns a new index that's read-write and stores vector of ``f`` dimensions. Metric can be ``"angular"``, ``"euclidean"``, ``"manhattan"``, or ``"hamming"``.
+* ``AnnoyIndex(f, metric='angular')`` returns a new index that's read-write and stores vector of ``f`` dimensions. Metric can be ``"angular"``, ``"euclidean"``, ``"manhattan"``, ``"hamming"``, or ``"dot"``.
 * ``a.add_item(i, v)`` adds item ``i`` (any nonnegative integer) with vector ``v``. Note that it will allocate memory for ``max(i)+1`` items.
 * ``a.build(n_trees)`` builds a forest of ``n_trees`` trees. More trees gives higher precision when querying. After calling ``build``, no more items can be added.
 * ``a.save(fn)`` saves the index to disk.
@@ -103,7 +103,7 @@ There are just two parameters you can use to tune Annoy: the number of trees ``n
 * ``n_trees`` is provided during build time and affects the build time and the index size. A larger value will give more accurate results, but larger indexes.
 * ``search_k`` is provided in runtime and affects the search performance. A larger value will give more accurate results, but will take longer time to return.
 
-If ``search_k`` is not provided, it will default to ``n * n_trees`` where ``n`` is the number of approximate nearest neighbors. Otherwise, ``search_k`` and ``n_trees`` are roughly independent, i.e. a the value of ``n_trees`` will not affect search time if ``search_k`` is held constant and vice versa. Basically it's recommended to set ``n_trees`` as large as possible given the amount of memory you can afford, and it's recommended to set ``search_k`` as large as possible given the time constraints you have for the queries.
+If ``search_k`` is not provided, it will default to ``n * n_trees * D`` where ``n`` is the number of approximate nearest neighbors and ``D`` is a constant depending on the metric. Otherwise, ``search_k`` and ``n_trees`` are roughly independent, i.e. a the value of ``n_trees`` will not affect search time if ``search_k`` is held constant and vice versa. Basically it's recommended to set ``n_trees`` as large as possible given the amount of memory you can afford, and it's recommended to set ``search_k`` as large as possible given the time constraints you have for the queries.
 
 How does it work
 ----------------
@@ -113,6 +113,8 @@ Using `random projections <http://en.wikipedia.org/wiki/Locality-sensitive_hashi
 We do this k times so that we get a forest of trees. k has to be tuned to your need, by looking at what tradeoff you have between precision and performance.
 
 Hamming distance (contributed by `Martin Aumüller <https://github.com/maumueller>`__) packs the data into 64-bit integers under the hood and uses built-in bit count primitives so it could be quite fast. All splits are axis-aligned.
+
+Dot Product distance (contributed by `Peter Sobot <https://github.com/psobot>`__) reduces the provided vectors from dot (or "inner-product") space to a more query-friendly cosine space using [a method by Bachrach et. al., at Microsoft Research, published in 2014](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/XboxInnerProduct.pdf).
 
 More info
 ---------

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -416,7 +416,7 @@ struct DotProduct : Angular {
 
   template<typename S, typename T>
   static inline T margin(const Node<S, T>* n, const T* y, int f) {
-    return dot(n->v, y, f);
+    return dot(n->v, y, f) + (n->dot_factor * n->dot_factor);
   }
 
   template<typename S, typename T, typename Random>

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -729,11 +729,15 @@ public:
     _allocate_size(item + 1);
     Node* n = _get(item);
 
+    D::zero_value(n);
+
     n->children[0] = 0;
     n->children[1] = 0;
     n->n_descendants = 1;
 
-    memcpy(n->v, w, _f * sizeof(T));
+    for (int z = 0; z < _f; z++)
+      n->v[z] = w[z];
+
     D::init_node(n, _f);
 
     if (item >= _n_items)

--- a/test/dot_index_test.py
+++ b/test/dot_index_test.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import numpy
+import random
+from common import TestCase
+from annoy import AnnoyIndex
+
+
+def dot_metric(a, b):
+    return -numpy.dot(a, b)
+
+
+def similarity(a, b):
+    # Could replace this with kendall-tau if we're comfortable
+    # bringing in scipy as a test dependency.
+    return float(len(set(a) & set(b))) / float(len(set(a) | set(b)))
+
+
+class DotIndexTest(TestCase):
+    def test_get_nns_by_vector(self):
+        f = 2
+        i = AnnoyIndex(f, 'dot')
+        i.add_item(0, [2, 2])
+        i.add_item(1, [3, 2])
+        i.add_item(2, [3, 3])
+        i.build(10)
+
+        self.assertEqual(i.get_nns_by_vector([4, 4], 3), [2, 1, 0])
+        self.assertEqual(i.get_nns_by_vector([1, 1], 3), [2, 1, 0])
+        self.assertEqual(i.get_nns_by_vector([4, 2], 3), [2, 1, 0])
+
+    def test_get_nns_by_item(self):
+        f = 2
+        i = AnnoyIndex(f, 'dot')
+        i.add_item(0, [2, 2])
+        i.add_item(1, [3, 2])
+        i.add_item(2, [3, 3])
+        i.build(10)
+
+        self.assertEqual(i.get_nns_by_item(0, 3), [2, 1, 0])
+        self.assertEqual(i.get_nns_by_item(2, 3), [2, 1, 0])
+
+    def test_dist(self):
+        f = 2
+        i = AnnoyIndex(f, 'dot')
+        i.add_item(0, [0, 1])
+        i.add_item(1, [1, 1])
+        i.add_item(2, [0, 0])
+
+        self.assertAlmostEqual(i.get_distance(0, 1), -1.0)
+        self.assertAlmostEqual(i.get_distance(1, 2), 0.0)
+
+    def test_large_index(self):
+        f = 1
+        i = AnnoyIndex(f, 'dot')
+        for j in range(0, 10000):
+            i.add_item(j, [j])
+
+        i.build(10)
+        for j in range(0, 10000):
+            self.assertTrue(i.get_nns_by_item(j, 1)[0] >= j)
+
+    def test_random_accuracy(self):
+        n = 10
+
+        n_trees = 10
+        n_points = 1000
+        n_rounds = 5
+
+        for r in range(n_rounds):
+            # create random points at distance x
+            f = 10
+            idx = AnnoyIndex(f, 'dot')
+
+            data = numpy.array([
+                [random.gauss(0, 1) for z in range(f)]
+                for j in range(n_points)
+            ])
+
+            expected_results = [
+                sorted(
+                    range(n_points),
+                    key=lambda j: dot_metric(data[i], data[j])
+                )[:n]
+                for i in range(n_points)
+            ]
+
+            for i, vec in enumerate(data):
+                idx.add_item(i, vec)
+
+            idx.build(n_trees)
+
+            for i in range(n_points):
+                nns = idx.get_nns_by_vector(data[i], n)
+                self.assertGreater(similarity(nns, expected_results[i]), 0.9)
+
+    def precision(self, n, n_trees=10, n_points=10000, n_rounds=10):
+        found = 0
+        for r in range(n_rounds):
+            # create random points at distance x
+            f = 10
+            i = AnnoyIndex(f, 'dot')
+            for j in range(n_points):
+                p = [random.gauss(0, 1) for z in range(f)]
+                norm = sum([pi ** 2 for pi in p]) ** 0.5
+                x = [pi / norm * j for pi in p]
+                i.add_item(j, x)
+
+            i.build(n_trees)
+
+            nns = i.get_nns_by_vector([0] * f, n)
+            self.assertEqual(nns, sorted(nns))  # should be in order
+            # The number of gaps should be equal to the last item minus n-1
+            found += len([y for y in nns if y < n])
+
+        return 1.0 * found / (n * n_rounds)
+
+    def test_precision_10(self):
+        self.assertTrue(self.precision(10) >= 0.98)
+
+    def test_precision_100(self):
+        self.assertTrue(self.precision(100) >= 0.98)
+
+    def test_precision_1000(self):
+        self.assertTrue(self.precision(1000) >= 0.98)
+
+    def test_precision_1000_fewer_trees(self):
+        self.assertTrue(self.precision(1000, n_trees=4) >= 0.98)
+
+    def test_get_nns_with_distances(self):
+        f = 3
+        i = AnnoyIndex(f, 'dot')
+        i.add_item(0, [0, 0, 2])
+        i.add_item(1, [0, 1, 1])
+        i.add_item(2, [1, 0, 0])
+        i.build(10)
+
+        l, d = i.get_nns_by_item(0, 3, -1, True)
+        self.assertEqual(l, [0, 1, 2])
+        self.assertAlmostEqual(d[0], -4.0)
+        self.assertAlmostEqual(d[1], -2.0)
+        self.assertAlmostEqual(d[2], -0.0)
+
+        l, d = i.get_nns_by_vector([2, 2, 2], 3, -1, True)
+        self.assertEqual(l, [0, 1, 2])
+        self.assertAlmostEqual(d[0], -4.0)
+        self.assertAlmostEqual(d[1], -4.0)
+        self.assertAlmostEqual(d[2], -2.0)
+
+    def test_include_dists(self):
+        f = 40
+        i = AnnoyIndex(f, 'dot')
+        v = numpy.random.normal(size=f)
+        i.add_item(0, v)
+        i.add_item(1, -v)
+        i.build(10)
+
+        indices, dists = i.get_nns_by_item(0, 2, 10, True)
+        self.assertEqual(indices, [0, 1])
+        self.assertAlmostEqual(dists[0], -numpy.dot(v, v))
+
+    def test_distance_consistency(self):
+        n, f = 1000, 3
+        i = AnnoyIndex(f, 'dot')
+        for j in range(n):
+            i.add_item(j, numpy.random.normal(size=f))
+        i.build(10)
+        for a in random.sample(range(n), 100):
+            indices, dists = i.get_nns_by_item(a, 100, include_distances=True)
+            for b, dist in zip(indices, dists):
+                self.assertAlmostEqual(dist, -numpy.dot(
+                    i.get_item_vector(a),
+                    i.get_item_vector(b)
+                ))
+                self.assertEqual(dist, i.get_distance(a, b))

--- a/test/dot_index_test.py
+++ b/test/dot_index_test.py
@@ -72,14 +72,8 @@ class DotIndexTest(TestCase):
         for j in range(0, 10000):
             self.assertTrue(i.get_nns_by_item(j, 1)[0] >= j)
 
-    def test_random_accuracy(self):
-        n = 10
-
-        n_trees = 10
-        n_points = 1000
-        n_rounds = 5
-
-        random.seed(1)
+    def precision(self, n, n_trees=10, n_points=1000, n_rounds=5):
+        total_similarity = 0.
 
         for r in range(n_rounds):
             # create random points at distance x
@@ -106,44 +100,25 @@ class DotIndexTest(TestCase):
 
             for i in range(n_points):
                 nns = idx.get_nns_by_vector(data[i], n)
-                self.assertGreater(similarity(nns, expected_results[i]), 0.75)
+                total_similarity += similarity(nns, expected_results[i])
 
-    def precision(self, n, n_trees=10, n_points=10000, n_rounds=10):
-        found = 0
-        for r in range(n_rounds):
-            # create random points at distance x
-            f = 10
-            i = AnnoyIndex(f, 'dot')
-            for j in range(n_points):
-                p = [random.gauss(0, 1) for z in range(f)]
-                norm = sum([pi ** 2 for pi in p]) ** 0.5
-                x = [pi / norm * j for pi in p]
-                i.add_item(j, x)
-
-            i.build(n_trees)
-
-            nns = i.get_nns_by_vector([0] * f, n)
-            self.assertEqual(nns, sorted(nns))  # should be in order
-            # The number of gaps should be equal to the last item minus n-1
-            found += len([y for y in nns if y < n])
-
-        return 1.0 * found / (n * n_rounds)
+        return total_similarity / float(n_rounds * n_points)
 
     def test_precision_10(self):
-        random.seed(1)
-        self.assertTrue(self.precision(10) >= 0.98)
+        value = self.precision(10)
+        self.assertGreaterEqual(value, 0.98)
 
     def test_precision_100(self):
-        random.seed(1)
-        self.assertTrue(self.precision(100) >= 0.98)
+        value = self.precision(100)
+        self.assertGreaterEqual(value, 0.98)
 
     def test_precision_1000(self):
-        random.seed(1)
-        self.assertTrue(self.precision(1000) >= 0.98)
+        value = self.precision(1000)
+        self.assertGreaterEqual(value, 0.98)
 
     def test_precision_1000_fewer_trees(self):
-        random.seed(1)
-        self.assertTrue(self.precision(1000, n_trees=4) >= 0.98)
+        value = self.precision(1000, n_trees=4)
+        self.assertGreaterEqual(value, 0.98)
 
     def test_get_nns_with_distances(self):
         f = 3

--- a/test/dot_index_test.py
+++ b/test/dot_index_test.py
@@ -62,16 +62,6 @@ class DotIndexTest(TestCase):
         self.assertAlmostEqual(i.get_distance(0, 1), -1.0)
         self.assertAlmostEqual(i.get_distance(1, 2), 0.0)
 
-    def test_large_index(self):
-        f = 1
-        i = AnnoyIndex(f, 'dot')
-        for j in range(0, 10000):
-            i.add_item(j, [j])
-
-        i.build(10)
-        for j in range(0, 10000):
-            self.assertTrue(i.get_nns_by_item(j, 1)[0] >= j)
-
     def precision(self, n, n_trees=10, n_points=1000, n_rounds=5):
         total_similarity = 0.
 

--- a/test/dot_index_test.py
+++ b/test/dot_index_test.py
@@ -79,6 +79,8 @@ class DotIndexTest(TestCase):
         n_points = 1000
         n_rounds = 5
 
+        random.seed(1)
+
         for r in range(n_rounds):
             # create random points at distance x
             f = 10
@@ -104,7 +106,7 @@ class DotIndexTest(TestCase):
 
             for i in range(n_points):
                 nns = idx.get_nns_by_vector(data[i], n)
-                self.assertGreater(similarity(nns, expected_results[i]), 0.9)
+                self.assertGreater(similarity(nns, expected_results[i]), 0.75)
 
     def precision(self, n, n_trees=10, n_points=10000, n_rounds=10):
         found = 0
@@ -128,15 +130,19 @@ class DotIndexTest(TestCase):
         return 1.0 * found / (n * n_rounds)
 
     def test_precision_10(self):
+        random.seed(1)
         self.assertTrue(self.precision(10) >= 0.98)
 
     def test_precision_100(self):
+        random.seed(1)
         self.assertTrue(self.precision(100) >= 0.98)
 
     def test_precision_1000(self):
+        random.seed(1)
         self.assertTrue(self.precision(1000) >= 0.98)
 
     def test_precision_1000_fewer_trees(self):
+        random.seed(1)
         self.assertTrue(self.precision(1000, n_trees=4) >= 0.98)
 
     def test_get_nns_with_distances(self):


### PR DESCRIPTION
This PR:
 - adds a `DotProduct` metric, using the negative of the dot product between two vectors as a pseudo-distance metric.
 - makes this metric available under the string name `"dot"` in the standard Annoy interface
 - adds tests for this new metric, similar to the existing tests for the `Euclidean` metric.

You might ask - why add `dot` when we already have `angular`, which is basically just `dot` but divided by magnitude? Well, for some recommender systems (including some matrix factorization collaborative filters), the dot product between the user and item pair is a prediction of affinity between that user and item. ([Here's a great example](https://github.com/jfkirk/tensorrec/blob/master/tensorrec/tensorrec.py#L30) from @jfkirk.)