### PR TITLE
example precision_test.cpp may fail to compile due to lack of <random> header

### DIFF
--- a/examples/precision_test.cpp
+++ b/examples/precision_test.cpp
@@ -14,7 +14,7 @@
 #include <chrono>
 #include <algorithm>
 #include <map>
-
+#include <random>
 
 
 int precision(int f=40, int n=1000000){


### PR DESCRIPTION
example precision_test.cpp may fail to compile due to lack of <random> header in my  two testbed:

ubuntu-18.04.1-desktop-amd64 with g++ (Ubuntu 7.3.0-16ubuntu3) 7.3.0
manjaro-xfce-17.1.11-stable-x86_64 with g++ (GCC) 8.1.1 20180531

it will report:
precision_test.cpp:23:7: error: ‘default_random_engine’ is not a member of ‘std’
precision_test.cpp:24:7: error: ‘normal_distribution’ is not a member of ‘std’

so a small fix and PR here 