### PR TITLE
Update tested versions to match travis build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Summary of features
 * Small memory usage
 * Lets you share memory between multiple processes
 * Index creation is separate from lookup (in particular you can not add more items once the tree has been created)
-* Native Python support, tested with 2.6, 2.7, 3.3, 3.4, 3.5
+* Native Python support, tested with 2.7, 3.6, and 3.7.
 
 Python code example
 -------------------


### PR DESCRIPTION
Travis builds 2.7, 3.6, 3.7. Updating README to reflect that.