### PR TITLE
test for msc_ver and mingw

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -35,12 +35,14 @@ typedef unsigned __int64  uint64_t;
 #include <stdint.h>
 #endif
 
-#ifdef _MSC_VER
-#define NOMINMAX
-#include "mman.h"
-#include <windows.h>
+#if defined(_MSC_VER) || defined(__MINGW32__)
+ #ifndef NOMINMAX
+  #define NOMINMAX
+ #endif
+ #include "mman.h"
+ #include <windows.h>
 #else
-#include <sys/mman.h>
+ #include <sys/mman.h>
 #endif
 
 #include <string.h>


### PR DESCRIPTION
This reflects the change I had to make for the most recent RcppAnnoy upload:

- for R the Windows compiler is always MinGW's `gcc`;
- we need to test for it to in order to get `mman.h` included;
- we also already have `NOMINMAX` defined so this gets an extra test.