### PR TITLE
Metrics mismatch warning

### DIFF
--- a/examples/mmap_test.py
+++ b/examples/mmap_test.py
@@ -1,6 +1,6 @@
 from annoy import AnnoyIndex
 
-a = AnnoyIndex(3)
+a = AnnoyIndex(3, 'angular')
 a.add_item(0, [1, 0, 0])
 a.add_item(1, [0, 1, 0])
 a.add_item(2, [0, 0, 1])

--- a/examples/precision_test.py
+++ b/examples/precision_test.py
@@ -10,7 +10,7 @@ except NameError:
 
 n, f = 100000, 40
 
-t = AnnoyIndex(f)
+t = AnnoyIndex(f, 'angular')
 for i in xrange(n):
     v = []
     for z in xrange(f):

--- a/examples/simple_test.py
+++ b/examples/simple_test.py
@@ -1,6 +1,6 @@
 from annoy import AnnoyIndex
 
-a = AnnoyIndex(3)
+a = AnnoyIndex(3, 'angular')
 a.add_item(0, [1, 0, 0])
 a.add_item(1, [0, 1, 0])
 a.add_item(2, [0, 0, 1])

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -123,7 +123,12 @@ py_an_new(PyTypeObject *type, PyObject *args, PyObject *kwargs) {
   static char const * kwlist[] = {"f", "metric", NULL};
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "i|s", (char**)kwlist, &self->f, &metric))
     return NULL;
-  if (!metric || !strcmp(metric, "angular")) {
+  if (!metric) {
+    // This keeps coming up, see #368 etc
+    PyErr_WarnEx(PyExc_DeprecationWarning, "The default argument for metric will be removed "
+		 " in future version of Annoy. Please pass metric='angular' explicitly.", 1);
+    self->ptr = new AnnoyIndex<int32_t, float, Angular, Kiss64Random>(self->f);
+  } else if (strcmp(metric, "angular")) {
    self->ptr = new AnnoyIndex<int32_t, float, Angular, Kiss64Random>(self->f);
   } else if (!strcmp(metric, "euclidean")) {
     self->ptr = new AnnoyIndex<int32_t, float, Euclidean, Kiss64Random>(self->f);

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -125,8 +125,8 @@ py_an_new(PyTypeObject *type, PyObject *args, PyObject *kwargs) {
     return NULL;
   if (!metric) {
     // This keeps coming up, see #368 etc
-    PyErr_WarnEx(PyExc_DeprecationWarning, "The default argument for metric will be removed "
-		 " in future version of Annoy. Please pass metric='angular' explicitly.", 1);
+    PyErr_WarnEx(PyExc_FutureWarning, "The default argument for metric will be removed "
+		 "in future version of Annoy. Please pass metric='angular' explicitly.", 1);
     self->ptr = new AnnoyIndex<int32_t, float, Angular, Kiss64Random>(self->f);
   } else if (!strcmp(metric, "angular")) {
    self->ptr = new AnnoyIndex<int32_t, float, Angular, Kiss64Random>(self->f);

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -128,7 +128,7 @@ py_an_new(PyTypeObject *type, PyObject *args, PyObject *kwargs) {
     PyErr_WarnEx(PyExc_DeprecationWarning, "The default argument for metric will be removed "
 		 " in future version of Annoy. Please pass metric='angular' explicitly.", 1);
     self->ptr = new AnnoyIndex<int32_t, float, Angular, Kiss64Random>(self->f);
-  } else if (strcmp(metric, "angular")) {
+  } else if (!strcmp(metric, "angular")) {
    self->ptr = new AnnoyIndex<int32_t, float, Angular, Kiss64Random>(self->f);
   } else if (!strcmp(metric, "euclidean")) {
     self->ptr = new AnnoyIndex<int32_t, float, Euclidean, Kiss64Random>(self->f);

--- a/test/angular_index_test.py
+++ b/test/angular_index_test.py
@@ -117,16 +117,16 @@ class AngularIndexTest(TestCase):
         return 1.0 * found / (n * n_rounds)
 
     def test_precision_1(self):
-        self.assertTrue(self.precision(1) >= 0.98)
+        self.assertGreaterEqual(self.precision(1), 0.98)
 
     def test_precision_10(self):
-        self.assertTrue(self.precision(10) >= 0.98)
+        self.assertGreaterEqual(self.precision(10), 0.98)
 
     def test_precision_100(self):
-        self.assertTrue(self.precision(100) >= 0.98)
+        self.asserGreaterEqual(self.precision(100), 0.98)
 
     def test_precision_1000(self):
-        self.assertTrue(self.precision(1000) >= 0.98)
+        self.assertGreaterEqual(self.precision(1000), 0.98)
 
     def test_load_save_get_item_vector(self):
         f = 3

--- a/test/angular_index_test.py
+++ b/test/angular_index_test.py
@@ -21,7 +21,7 @@ from annoy import AnnoyIndex
 class AngularIndexTest(TestCase):
     def test_get_nns_by_vector(self):
         f = 3
-        i = AnnoyIndex(f)
+        i = AnnoyIndex(f, 'angular')
         i.add_item(0, [0, 0, 1])
         i.add_item(1, [0, 1, 0])
         i.add_item(2, [1, 0, 0])
@@ -33,7 +33,7 @@ class AngularIndexTest(TestCase):
 
     def test_get_nns_by_item(self):
         f = 3
-        i = AnnoyIndex(f)
+        i = AnnoyIndex(f, 'angular')
         i.add_item(0, [2, 1, 0])
         i.add_item(1, [1, 2, 0])
         i.add_item(2, [0, 0, 1])
@@ -45,7 +45,7 @@ class AngularIndexTest(TestCase):
 
     def test_dist(self):
         f = 2
-        i = AnnoyIndex(f)
+        i = AnnoyIndex(f, 'angular')
         i.add_item(0, [0, 1])
         i.add_item(1, [1, 1])
 
@@ -53,7 +53,7 @@ class AngularIndexTest(TestCase):
 
     def test_dist_2(self):
         f = 2
-        i = AnnoyIndex(f)
+        i = AnnoyIndex(f, 'angular')
         i.add_item(0, [1000, 0])
         i.add_item(1, [10, 0])
 
@@ -61,7 +61,7 @@ class AngularIndexTest(TestCase):
 
     def test_dist_3(self):
         f = 2
-        i = AnnoyIndex(f)
+        i = AnnoyIndex(f, 'angular')
         i.add_item(0, [97, 0])
         i.add_item(1, [42, 42])
 
@@ -71,7 +71,7 @@ class AngularIndexTest(TestCase):
 
     def test_dist_degen(self):
         f = 2
-        i = AnnoyIndex(f)
+        i = AnnoyIndex(f, 'angular')
         i.add_item(0, [1, 0])
         i.add_item(1, [0, 0])
 
@@ -80,7 +80,7 @@ class AngularIndexTest(TestCase):
     def test_large_index(self):
         # Generate pairs of random points where the pair is super close
         f = 10
-        i = AnnoyIndex(f)
+        i = AnnoyIndex(f, 'angular')
         for j in range(0, 10000, 2):
             p = [random.gauss(0, 1) for z in range(f)]
             f1 = random.random() + 1
@@ -100,7 +100,7 @@ class AngularIndexTest(TestCase):
         for r in range(n_rounds):
             # create random points at distance x from (1000, 0, 0, ...)
             f = 10
-            i = AnnoyIndex(f, 'euclidean')
+            i = AnnoyIndex(f, 'angular')
             for j in range(n_points):
                 p = [random.gauss(0, 1) for z in range(f - 1)]
                 norm = sum([pi ** 2 for pi in p]) ** 0.5
@@ -130,7 +130,7 @@ class AngularIndexTest(TestCase):
 
     def test_load_save_get_item_vector(self):
         f = 3
-        i = AnnoyIndex(f)
+        i = AnnoyIndex(f, 'angular')
         i.add_item(0, [1.1, 2.2, 3.3])
         i.add_item(1, [4.4, 5.5, 6.6])
         i.add_item(2, [7.7, 8.8, 9.9])
@@ -139,13 +139,13 @@ class AngularIndexTest(TestCase):
         self.assertTrue(i.build(10))
         self.assertTrue(i.save('blah.ann'))
         numpy.testing.assert_array_almost_equal(i.get_item_vector(1), [4.4, 5.5, 6.6])
-        j = AnnoyIndex(f)
+        j = AnnoyIndex(f, 'angular')
         self.assertTrue(j.load('blah.ann'))
         numpy.testing.assert_array_almost_equal(j.get_item_vector(2), [7.7, 8.8, 9.9])
 
     def test_get_nns_search_k(self):
         f = 3
-        i = AnnoyIndex(f)
+        i = AnnoyIndex(f, 'angular')
         i.add_item(0, [0, 0, 1])
         i.add_item(1, [0, 1, 0])
         i.add_item(2, [1, 0, 0])
@@ -157,7 +157,7 @@ class AngularIndexTest(TestCase):
     def test_include_dists(self):
         # Double checking issue 112
         f = 40
-        i = AnnoyIndex(f)
+        i = AnnoyIndex(f, 'angular')
         v = numpy.random.normal(size=f)
         i.add_item(0, v)
         i.add_item(1, -v)
@@ -170,7 +170,7 @@ class AngularIndexTest(TestCase):
 
     def test_include_dists_check_ranges(self):
         f = 3
-        i = AnnoyIndex(f)
+        i = AnnoyIndex(f, 'angular')
         for j in range(100000):
             i.add_item(j, numpy.random.normal(size=f))
         i.build(10)
@@ -180,7 +180,7 @@ class AngularIndexTest(TestCase):
 
     def test_distance_consistency(self):
         n, f = 1000, 3
-        i = AnnoyIndex(f)
+        i = AnnoyIndex(f, 'angular')
         for j in range(n):
             i.add_item(j, numpy.random.normal(size=f))
         i.build(10)
@@ -199,27 +199,27 @@ class AngularIndexTest(TestCase):
 
     def test_only_one_item(self):
         # reported to annoy-user by Kireet Reddy
-        idx = AnnoyIndex(100)
+        idx = AnnoyIndex(100, 'angular')
         idx.add_item(0, numpy.random.randn(100))
         idx.build(n_trees=10)
         idx.save('foo.idx')
-        idx = AnnoyIndex(100)
+        idx = AnnoyIndex(100, 'angular')
         idx.load('foo.idx')
         self.assertEquals(idx.get_n_items(), 1)
         self.assertEquals(idx.get_nns_by_vector(vector=numpy.random.randn(100), n=50, include_distances=False), [0])
 
     def test_no_items(self):
-        idx = AnnoyIndex(100)
+        idx = AnnoyIndex(100, 'angular')
         idx.build(n_trees=10)
         idx.save('foo.idx')
-        idx = AnnoyIndex(100)
+        idx = AnnoyIndex(100, 'angular')
         idx.load('foo.idx')
         self.assertEquals(idx.get_n_items(), 0)
         self.assertEquals(idx.get_nns_by_vector(vector=numpy.random.randn(100), n=50, include_distances=False), [])
 
     def test_single_vector(self):
         # https://github.com/spotify/annoy/issues/194
-        a = AnnoyIndex(3)
+        a = AnnoyIndex(3, 'angular')
         a.add_item(0, [1, 0, 0])
         a.build(10)
         a.save('1.ann')

--- a/test/angular_index_test.py
+++ b/test/angular_index_test.py
@@ -95,7 +95,7 @@ class AngularIndexTest(TestCase):
             self.assertEqual(i.get_nns_by_item(j, 2), [j, j+1])
             self.assertEqual(i.get_nns_by_item(j+1, 2), [j+1, j])
 
-    def precision(self, n, n_trees=10, n_points=10000, n_rounds=10):
+    def precision(self, n, n_trees=10, n_points=10000, n_rounds=10, search_k=100000):
         found = 0
         for r in range(n_rounds):
             # create random points at distance x from (1000, 0, 0, ...)
@@ -109,7 +109,7 @@ class AngularIndexTest(TestCase):
 
             i.build(n_trees)
 
-            nns = i.get_nns_by_vector([1000] + [0] * (f-1), n)
+            nns = i.get_nns_by_vector([1000] + [0] * (f-1), n, search_k)
             self.assertEqual(nns, sorted(nns))  # should be in order
             # The number of gaps should be equal to the last item minus n-1
             found += len([x for x in nns if x < n])
@@ -123,7 +123,7 @@ class AngularIndexTest(TestCase):
         self.assertGreaterEqual(self.precision(10), 0.98)
 
     def test_precision_100(self):
-        self.asserGreaterEqual(self.precision(100), 0.98)
+        self.assertGreaterEqual(self.precision(100), 0.98)
 
     def test_precision_1000(self):
         self.assertGreaterEqual(self.precision(1000), 0.98)

--- a/test/holes_test.py
+++ b/test/holes_test.py
@@ -21,7 +21,7 @@ from annoy import AnnoyIndex
 class HolesTest(TestCase):
     def test_random_holes(self):
         f = 10
-        index = AnnoyIndex(f)
+        index = AnnoyIndex(f, 'angular')
         valid_indices = random.sample(range(2000), 1000) # leave holes
         for i in valid_indices:
             v = numpy.random.normal(size=(f,))
@@ -38,7 +38,7 @@ class HolesTest(TestCase):
                 self.assertTrue(j in valid_indices)
 
     def _test_holes_base(self, n, f=100, base_i=100000):
-        annoy = AnnoyIndex(f)
+        annoy = AnnoyIndex(f, 'angular')
         for i in range(n):
             annoy.add_item(base_i + i, numpy.random.normal(size=(f,)))
         annoy.build(100)

--- a/test/index_test.py
+++ b/test/index_test.py
@@ -20,11 +20,11 @@ from annoy import AnnoyIndex
 
 class IndexTest(TestCase):
     def test_not_found_tree(self):
-        i = AnnoyIndex(10)
+        i = AnnoyIndex(10, 'angular')
         self.assertRaises(IOError, i.load, 'nonexists.tree')
 
     def test_binary_compatibility(self):
-        i = AnnoyIndex(10)
+        i = AnnoyIndex(10, 'angular')
         i.load('test/test.tree')
 
         # This might change in the future if we change the search algorithm, but in that case let's update the test
@@ -32,67 +32,67 @@ class IndexTest(TestCase):
 
     def test_load_unload(self):
         # Issue #108
-        i = AnnoyIndex(10)
+        i = AnnoyIndex(10, 'angular')
         for x in range(100000):
             i.load('test/test.tree')
             i.unload()
 
     def test_construct_load_destruct(self):
         for x in range(100000):
-            i = AnnoyIndex(10)
+            i = AnnoyIndex(10, 'angular')
             i.load('test/test.tree')
 
     def test_construct_destruct(self):
         for x in range(100000):
-            i = AnnoyIndex(10)
+            i = AnnoyIndex(10, 'angular')
             i.add_item(1000, [random.gauss(0, 1) for z in range(10)])
 
     def test_save_twice(self):
         # Issue #100
-        t = AnnoyIndex(10)
+        t = AnnoyIndex(10, 'angular')
         t.save("t.ann")
         t.save("t.ann")
 
     def test_load_save(self):
         # Issue #61
-        i = AnnoyIndex(10)
+        i = AnnoyIndex(10, 'angular')
         i.load('test/test.tree')
         u = i.get_item_vector(99)
         i.save('i.tree')
         v = i.get_item_vector(99)
         self.assertEqual(u, v)
-        j = AnnoyIndex(10)
+        j = AnnoyIndex(10, 'angular')
         j.load('test/test.tree')
         w = i.get_item_vector(99)
         self.assertEqual(u, w)
         # Ensure specifying if prefault is allowed does not impact result
         j.save('j.tree', True)
-        k = AnnoyIndex(10)
+        k = AnnoyIndex(10, 'angular')
         k.load('j.tree', True)
         x = k.get_item_vector(99)
         self.assertEqual(u, x)
         k.save('k.tree', False)
-        l = AnnoyIndex(10)
+        l = AnnoyIndex(10, 'angular')
         l.load('k.tree', False)
         y = l.get_item_vector(99)
         self.assertEqual(u, y)
 
     def test_save_without_build(self):
         # Issue #61
-        i = AnnoyIndex(10)
+        i = AnnoyIndex(10, 'angular')
         i.add_item(1000, [random.gauss(0, 1) for z in range(10)])
         i.save('x.tree')
-        j = AnnoyIndex(10)
+        j = AnnoyIndex(10, 'angular')
         j.load('x.tree')
         j.build(10)
         
     def test_unbuild_with_loaded_tree(self):
-        i = AnnoyIndex(10)
+        i = AnnoyIndex(10, 'angular')
         i.load('test/test.tree')
         i.unbuild()
 
     def test_seed(self):
-        i = AnnoyIndex(10)
+        i = AnnoyIndex(10, 'angular')
         i.load('test/test.tree')
         i.set_seed(42)
 
@@ -112,7 +112,7 @@ class IndexTest(TestCase):
 
     def test_item_vector_after_save(self):
         # Issue #279
-        a = AnnoyIndex(3)
+        a = AnnoyIndex(3, 'angular')
         a.verbose(True)
         a.add_item(1, [1, 0, 0])
         a.add_item(2, [0, 1, 0])
@@ -127,12 +127,12 @@ class IndexTest(TestCase):
         self.assertEqual(set(a.get_nns_by_item(1, 999)), set([1, 2, 3]))
 
     def test_prefault(self):
-        i = AnnoyIndex(10)
+        i = AnnoyIndex(10, 'angular')
         i.load('test/test.tree', prefault=True)
         self.assertEqual(i.get_nns_by_item(0, 10), [0, 85, 42, 11, 54, 38, 53, 66, 19, 31])
 
     def test_fail_save(self):
-        t = AnnoyIndex(40)
+        t = AnnoyIndex(40, 'angular')
         with self.assertRaises(IOError):
             t.save('')
 
@@ -141,7 +141,7 @@ class IndexTest(TestCase):
         f = 40
 
         # Build the initial index
-        t = AnnoyIndex(f)
+        t = AnnoyIndex(f, 'angular')
         for i in range(1000):
             v = [random.gauss(0, 1) for z in range(f)]
             t.add_item(i, v)
@@ -149,11 +149,11 @@ class IndexTest(TestCase):
         t.save('test.ann')
 
         # Load index file
-        t2 = AnnoyIndex(f)
+        t2 = AnnoyIndex(f, 'angular')
         t2.load('test.ann')
 
         # Overwrite index file
-        t3 = AnnoyIndex(f)
+        t3 = AnnoyIndex(f, 'angular')
         for i in range(500):
             v = [random.gauss(0, 1) for z in range(f)]
             t3.add_item(i, v)
@@ -169,7 +169,7 @@ class IndexTest(TestCase):
             nns = t2.get_nns_by_vector(v, 1000)  # Should not crash
 
     def test_get_n_trees(self):
-        i = AnnoyIndex(10)
+        i = AnnoyIndex(10, 'angular')
         i.load('test/test.tree')
         self.assertEqual(i.get_n_trees(), 10)
 
@@ -177,7 +177,7 @@ class IndexTest(TestCase):
         f = 40
 
         # Build the initial index
-        t = AnnoyIndex(f)
+        t = AnnoyIndex(f, 'angular')
         for i in range(1000):
             v = [random.gauss(0, 1) for z in range(f)]
             t.add_item(i, v)

--- a/test/seed_test.py
+++ b/test/seed_test.py
@@ -25,7 +25,7 @@ class SeedTest(TestCase):
 
         indexes = []
         for i in range(2):
-            index = AnnoyIndex(f)
+            index = AnnoyIndex(f, 'angular')
             index.set_seed(42)
             for j in range(X.shape[0]):
                 index.add_item(j, X[j])


### PR DESCRIPTION
Throw a FutureWarning if the metrics isn't provided explicitly – this should cover a common user error.

I'll make this an error in about a year.