### PR TITLE
Use fully qualified std::sort

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -1259,7 +1259,7 @@ protected:
 
     // Get distances for all items
     // To avoid calculating distance multiple times for any items, sort by id
-    sort(nns.begin(), nns.end());
+    std::sort(nns.begin(), nns.end());
     vector<pair<T, S> > nns_dist;
     S last = -1;
     for (size_t i = 0; i < nns.size(); i++) {


### PR DESCRIPTION
This fixes a compilation error in a really arcane environment I use. Anyway, `std` should be there.