### PR TITLE
assign ftruncate result to quieten g++

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -1121,7 +1121,7 @@ protected:
       void *old = _nodes;
       
       if (_on_disk) {
-        ftruncate(_fd, _s * new_nodes_size);
+        int rc = ftruncate(_fd, _s * new_nodes_size);
         _nodes = remap_memory(_nodes, _fd, _s * _nodes_size, _s * new_nodes_size);
       } else {
         _nodes = realloc(_nodes, _s * new_nodes_size);


### PR DESCRIPTION
While updating RcppAnnoy to the current annoy version, I noticed `g++` whining about this under the settings we use -- it is technically an unassigned return value so now we assign it.  To then ignore it :)