### PR TITLE
use return code, and only conditionally define ftruncate

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -1122,6 +1122,7 @@ protected:
       
       if (_on_disk) {
         int rc = ftruncate(_fd, _s * new_nodes_size);
+        if (_verbose && rc) showUpdate("File truncation error\n");
         _nodes = remap_memory(_nodes, _fd, _s * _nodes_size, _s * new_nodes_size);
       } else {
         _nodes = realloc(_nodes, _s * new_nodes_size);

--- a/src/mman.h
+++ b/src/mman.h
@@ -209,6 +209,7 @@ inline int munlock(const void *addr, size_t len)
     return -1;
 }
 
+#if !defined(__MINGW32__)
 int ftruncate(int fd, unsigned int size) {
     if (fd < 0) {
         errno = EBADF;
@@ -232,5 +233,6 @@ int ftruncate(int fd, unsigned int size) {
 
     return 0;
 }
+#endif
 
 #endif 


### PR DESCRIPTION
Follow-up to yesterday's #418 while preparing CRAN upload:

1.  Need to actually use return code from `ftruncate`.  Doh.  So added minimal output, conditional on `_verbose` being set as well.

2.  Turns out the Windows version of `g++` does not like the new definition of `ftruncate` as it has its own.  So `#if !defined` wrapped around it.

With that I am good.