### PR TITLE
Disallow saving an index that hasn't been built

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -978,6 +978,11 @@ public:
   }
 
   bool save(const char* filename, bool prefault=false, char** error=NULL) {
+    if (!_built) {
+      showUpdate("You can't save an index that hasn't been built\n");
+      if (error) *error = (char *)"You can't save an index that hasn't been built";
+      return false;
+    }
     if (_on_disk) {
       return true;
     } else {
@@ -1090,6 +1095,7 @@ public:
     if (_roots.size() > 1 && _get(_roots.front())->children[0] == _get(_roots.back())->children[0])
       _roots.pop_back();
     _loaded = true;
+    _built = true;
     _n_items = m;
     if (_verbose) showUpdate("found %lu roots with degree %d\n", _roots.size(), m);
     return true;

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -1057,10 +1057,8 @@ public:
       return false;
     } else if (size == 0) {
       showUpdate("Size of file is zero\n");
-      // TODO(erikbern): there is some weird test case failure because of this
-      // Let's fix separately!
-      // if (error) *error = (char *)"Size of file is zero";
-      // return false;
+      if (error) *error = (char *)"Size of file is zero";
+      return false;
     } else if (size % _s) {
       // Something is fishy with this index!
       showUpdate("Error: index size %zu is not a multiple of vector size %zu\n", (size_t)size, _s);

--- a/test/annoy_test.lua
+++ b/test/annoy_test.lua
@@ -496,16 +496,6 @@ describe("index test", function()
         assert.same(u, y)
     end)
 
-    it("save_without_build", function()
-        -- Issue #61
-        local i = AnnoyIndex(10)
-        i:add_item(1000, randomVector(10, 0, 1))
-        i:save('x.tree')
-        local j = AnnoyIndex(10)
-        j:load('x.tree')
-        j:build(10)
-    end)
-    
     it("on_disk_build", function()
         local f = 2
         local i = AnnoyIndex(f, 'euclidean')

--- a/test/index_test.py
+++ b/test/index_test.py
@@ -50,6 +50,9 @@ class IndexTest(TestCase):
     def test_save_twice(self):
         # Issue #100
         t = AnnoyIndex(10, 'angular')
+        for i in range(100):
+            t.add_item(i, [random.gauss(0, 1) for z in range(10)])
+        t.build(10)
         t.save("t.ann")
         t.save("t.ann")
 
@@ -78,13 +81,11 @@ class IndexTest(TestCase):
         self.assertEqual(u, y)
 
     def test_save_without_build(self):
-        # Issue #61
-        i = AnnoyIndex(10, 'angular')
-        i.add_item(1000, [random.gauss(0, 1) for z in range(10)])
-        i.save('x.tree')
-        j = AnnoyIndex(10, 'angular')
-        j.load('x.tree')
-        self.assertRaises(Exception, j.build, 10)
+        t = AnnoyIndex(10, 'angular')
+        for i in range(100):
+            t.add_item(i, [random.gauss(0, 1) for z in range(10)])
+        # Note: in earlier version, this was allowed (see eg #61)
+        self.assertRaises(Exception, t.save, 'x.tree')
         
     def test_unbuild_with_loaded_tree(self):
         i = AnnoyIndex(10, 'angular')


### PR DESCRIPTION
This was de facto not working, and to support it would have been kind of annoying. I think it was working at some point (see #61) but it must have broken later. Also seems like kind of a pointless feature to have.

Better to just be explicit that it doesn't work.

This will also let me fix the lseek warning messages properly.