### PR TITLE
Allow configuring target compile architecture as install-option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup, Extension
 import codecs
 import os
 import platform
-import sys
+from setuptools.command.install import install as _install
 
 readme_note = """\
 .. note::
@@ -32,28 +32,51 @@ readme_note = """\
 
 """
 
+extension_name = 'annoy.annoylib'
 with codecs.open('README.rst', encoding='utf-8') as fobj:
     long_description = readme_note + fobj.read()
 
-# Various platform-dependent extras
-extra_compile_args = []
-extra_link_args = []
 
-# Not all CPUs have march as a tuning parameter
-cputune = ['-march=native',]
-if platform.machine() == 'ppc64le':
-    extra_compile_args += ['-mcpu=native',]
+class install(_install):
+    '''
+    Install options for pip.
+    Ex: `pip3 install annoy --install-option="--march=haswell"`
+    '''
+    user_options = _install.user_options + [('march=', None, None)]
 
-if platform.machine() == 'x86_64':
-    extra_compile_args += cputune
+    def initialize_options(self):
+        _install.initialize_options(self)
+        self.march = None
 
-if os.name != 'nt':
-    extra_compile_args += ['-O3', '-ffast-math', '-fno-associative-math']
+    def finalize_options(self):
+        _install.finalize_options(self)
+        compile_args, link_args = [], []
 
-# #349: something with OS X Mojave causes libstd not to be found
-if platform.system() == 'Darwin':
-    extra_compile_args += ['-std=c++11', '-mmacosx-version-min=10.9']
-    extra_link_args += ['-stdlib=libc++', '-mmacosx-version-min=10.9']
+        # Not all CPUs have march as a tuning parameter
+        if self.march:
+            compile_args += ['-march={}'.format(self.march),]
+        elif platform.machine() == 'x86_64':
+            compile_args += ['-march=native',]
+
+        if platform.machine() == 'ppc64le':
+            compile_args += ['-mcpu=native',]
+
+        if os.name != 'nt':
+            compile_args += ['-O3', '-ffast-math', '-fno-associative-math']
+
+        # #349: something with OS X Mojave causes libstd not to be found
+        if platform.system() == 'Darwin':
+            compile_args += ['-std=c++11', '-mmacosx-version-min=10.9']
+            link_args += ['-stdlib=libc++', '-mmacosx-version-min=10.9']
+
+        for ext in self.distribution.ext_modules:
+            if ext.name == extension_name:
+                ext.extra_compile_args = compile_args
+                ext.extra_link_args = link_args
+
+    def run(self):
+        _install.run(self)
+
 
 setup(name='annoy',
       version='1.16.1',
@@ -61,10 +84,8 @@ setup(name='annoy',
       packages=['annoy'],
       ext_modules=[
         Extension(
-            'annoy.annoylib', ['src/annoymodule.cc'],
+            extension_name, ['src/annoymodule.cc'],
             depends=['src/annoylib.h', 'src/kissrandom.h', 'src/mman.h'],
-            extra_compile_args=extra_compile_args,
-            extra_link_args=extra_link_args,
         )
       ],
       long_description=long_description,
@@ -83,5 +104,6 @@ setup(name='annoy',
           'Programming Language :: Python :: 3.6',
       ],
       keywords='nns, approximate nearest neighbor search',
-      setup_requires=['nose>=1.0']
+      setup_requires=['nose>=1.0'],
+      cmdclass={"install": install}
     )

--- a/setup.py
+++ b/setup.py
@@ -55,10 +55,10 @@ if platform.system() == 'Darwin':
     extra_link_args += ['-stdlib=libc++', '-mmacosx-version-min=10.9']
 
 # Manual configuration, you're on your own here.
-manual_compiler_args = os.environ.get('ANNOY_COMPILER_ARGS', default=None)
+manual_compiler_args = os.environ.get('ANNOY_COMPILER_ARGS', None)
 if manual_compiler_args:
     extra_compile_args = manual_compiler_args.split(',')
-manual_linker_args = os.environ.get('ANNOY_LINKER_ARGS', default=None)
+manual_linker_args = os.environ.get('ANNOY_LINKER_ARGS', None)
 if manual_linker_args:
     extra_link_args = manual_linker_args.split(',')
 


### PR DESCRIPTION
Hi.

We're in a position of compiling a docker image containing Annoy on a build-server with a different architecture then our target server has. This may result in Annoy compiling with instructions that are unavailable at the target architecture. It would be super helpful if we could set this option with pip instead of precompiling Annoy somewhere else.

I've tested this locally like this: `pip install -v . --install-option="--march=knl"`. Everything seems to compile alright. 
Also, a regular install works as expected and should give the same compiler options as before `pip install -v .`

I get a `ModuleNotFoundError: No module named 'annoy.annoylib'` when trying to import my locally compiled version of both master, and my own build, so I'm pretty sure this is just my own pip-noobing showing it's face and not something breaking.

Having this resolved quickly would make our lives a lot easier :)