### PR TITLE
Add `numpy` and `h5py` as dependencies in setup.py's `tests_require`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,5 +90,6 @@ setup(name='annoy',
           'Programming Language :: Python :: 3.6',
       ],
       keywords='nns, approximate nearest neighbor search',
-      setup_requires=['nose>=1.0']
+      setup_requires=['nose>=1.0'],
+      tests_require=['numpy', 'h5py']
       )


### PR DESCRIPTION
`numpy` and `h5py` are required to run the tests but those dependencies
aren't currently specified anywhere AFAIK. When running the tests via
`python setup.py nosetests`, this will use any existing installed
packages (e.g. via pip) or download them to the `.eggs` directory if not
already installed. It makes the tests "just work" the first time you try
to run them after cloning the repo.