### PR TITLE
Fix #388 issue – Windows failure with large indexes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - os: osx
       language: generic
       env:
-        - TOXENV=py36
+        - TOXENV=py37
 
 env:
   matrix:

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -1044,7 +1044,11 @@ public:
       _fd = 0;
       return false;
     }
+#ifndef _MSC_VER
     off_t size = lseek(_fd, 0, SEEK_END);
+#else
+    off_t size = _lseeki64(_fd, 0, SEEK_END);
+#endif
     if (size == -1) {
       showUpdate("lseek returned -1\n");
       if (error) *error = strerror(errno);

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -983,8 +983,6 @@ public:
       // Delete file if it already exists (See issue #335)
       unlink(filename);
 
-      printf("path: %s\n", filename);
-
       FILE *f = fopen(filename, "wb");
       if (f == NULL) {
         showUpdate("Unable to open: %s\n", strerror(errno));

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -31,11 +31,14 @@
 typedef unsigned char     uint8_t;
 typedef signed __int32    int32_t;
 typedef unsigned __int64  uint64_t;
+typedef signed __int64    int64_t;
 #else
 #include <stdint.h>
 #endif
 
+
 #if defined(_MSC_VER) || defined(__MINGW32__)
+ #define off_t int64_t  // override definition
  #ifndef NOMINMAX
   #define NOMINMAX
  #endif


### PR DESCRIPTION
So far this is just a unit test. This runs well on my local computer (Mac) but should reproduce the failure in #388. I expect this to fail on Windows.

Removed a debug output left by accident earlier.