### PR TITLE
Fix misc minor compilation warnings

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -109,13 +109,10 @@ inline void set_error_from_string(char **error, const char* msg) {
 #endif
 
 #if !defined(NO_MANUAL_VECTORIZATION) && defined(__GNUC__) && (__GNUC__ >6) && defined(__AVX512F__)  // See #402
-#pragma message "Just for your information: using 512-bit AVX instructions"
 #define USE_AVX512
 #elif !defined(NO_MANUAL_VECTORIZATION) && defined(__AVX__) && defined (__SSE__) && defined(__SSE2__) && defined(__SSE3__)
-#pragma message "Just for your information: using 128-bit AVX instructions"
 #define USE_AVX
 #else
-#pragma message "Just for your information: using no AVX instructions"
 #endif
 
 #if defined(USE_AVX) || defined(USE_AVX512)
@@ -124,15 +121,6 @@ inline void set_error_from_string(char **error, const char* msg) {
 #elif defined(__GNUC__)
 #include <x86intrin.h>
 #endif
-#endif
-
-#ifndef ANNOY_NODE_ATTRIBUTE
-    #ifndef _MSC_VER
-        #define ANNOY_NODE_ATTRIBUTE __attribute__((__packed__))
-        // TODO: this is turned on by default, but may not work for all architectures! Need to investigate.
-    #else
-        #define ANNOY_NODE_ATTRIBUTE
-    #endif
 #endif
 
 
@@ -432,7 +420,7 @@ struct Base {
 
 struct Angular : Base {
   template<typename S, typename T>
-  struct ANNOY_NODE_ATTRIBUTE Node {
+  struct Node {
     /*
      * We store a binary tree where each node has two things
      * - A vector associated with it
@@ -516,7 +504,7 @@ struct Angular : Base {
 
 struct DotProduct : Angular {
   template<typename S, typename T>
-  struct ANNOY_NODE_ATTRIBUTE Node {
+  struct Node {
     /*
      * This is an extension of the Angular node with an extra attribute for the scaled norm.
      */
@@ -628,7 +616,7 @@ struct DotProduct : Angular {
 
 struct Hamming : Base {
   template<typename S, typename T>
-  struct ANNOY_NODE_ATTRIBUTE Node {
+  struct Node {
     S n_descendants;
     S children[2];
     T v[V_ARRAY_SIZE];
@@ -724,7 +712,7 @@ struct Hamming : Base {
 
 struct Minkowski : Base {
   template<typename S, typename T>
-  struct ANNOY_NODE_ATTRIBUTE Node {
+  struct Node {
     S n_descendants;
     T a; // need an extra constant term to determine the offset of the plane
     S children[2];

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -24,6 +24,24 @@ typedef signed __int32    int32_t;
 #endif
 
 
+#if defined(USE_AVX512)
+#define AVX_INFO "Using 512-bit AVX instructions"
+#elif defined(USE_AVX128)
+#define AVX_INFO "Using 128-bit AVX instructions"
+#else
+#define AVX_INFO "Not using AVX instructions"
+#endif
+
+#if defined(_MSC_VER)
+#define COMPILER_INFO "Compiled using MSC"
+#elif defined(__GNUC__)
+#define COMPILER_INFO "Compiled on GCC"
+#else
+#define COMPILER_INFO "Compiled on unknown platform"
+#endif
+
+#define ANNOY_DOC (COMPILER_INFO ". " AVX_INFO ".")
+
 #if PY_MAJOR_VERSION >= 3
 #define IS_PY3K
 #endif
@@ -542,7 +560,7 @@ static PyTypeObject PyAnnoyType = {
   0,                      /*tp_setattro*/
   0,                      /*tp_as_buffer*/
   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
-  "annoy objects",        /* tp_doc */
+  ANNOY_DOC,              /* tp_doc */
   0,                      /* tp_traverse */
   0,                      /* tp_clear */
   0,                      /* tp_richcompare */
@@ -570,7 +588,7 @@ static PyMethodDef module_methods[] = {
   static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "annoylib",          /* m_name */
-    "",                  /* m_doc */
+    ANNOY_DOC,           /* m_doc */
     -1,                  /* m_size */
     module_methods,      /* m_methods */
     NULL,                /* m_reload */

--- a/test/accuracy_test.py
+++ b/test/accuracy_test.py
@@ -36,7 +36,7 @@ class AccuracyTest(unittest.TestCase):
             print('downloading', url, '->', vectors_fn)
             urlretrieve(url, vectors_fn)
 
-        dataset_f = h5py.File(vectors_fn)
+        dataset_f = h5py.File(vectors_fn, 'r')
         distance = dataset_f.attrs['distance']
         f = dataset_f['train'].shape[1]
         annoy = AnnoyIndex(f, distance)


### PR DESCRIPTION
1. removed the struct packing – it's not needed since all members are 4 byte anyway (or sometimes 8 byte in Hamming)
2. fixed a super minor warning in one of the tests caused by a deprecated h5py method
3. removed the pragma messaged and made it a docstring on the module and object instead:

```
>>> annoy.AnnoyIndex.__doc__
'Compiled on GCC. Not using AVX instructions.'
```

(could probably add more to the docstring later)