### PR TITLE
A more informative error for  #423

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -1064,7 +1064,7 @@ public:
       return false;
     } else if (size % _s) {
       // Something is fishy with this index!
-      set_error_from_errno(error, "Index size is not a multiple of vector size");
+      set_error_from_errno(error, "Index size is not a multiple of vector size. Ensure you are opening using the same metric you used to create the index.");
       return false;
     }
 


### PR DESCRIPTION
Users might commonly save with a non-default metric, then try to open using the default metric. This gives a more informative message.

@erikbern let me know if you like the language and if line length is a concern.