### PR TITLE
Change strategy for when to draw random split

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -1158,11 +1158,21 @@ protected:
     }
   }
 
-  inline Node* _get(const S i) const {
+  Node* _get(const S i) const {
     return get_node_ptr<S, Node>(_nodes, _s, i);
   }
 
-  S _make_tree(const vector<S >& indices, bool is_root) {
+  bool _draw_random_split(const vector<S>& left_indices, const vector<S>& right_indices) {
+    if (left_indices.empty() || right_indices.empty())
+      return true;
+
+    float ls = (float)left_indices.size();
+    float rs = (float)right_indices.size();
+    float f = ls/(ls+rs);
+    return f < 0.01 || f > 0.99;
+  }
+
+  S _make_tree(const vector<S>& indices, bool is_root) {
     // The basic rule is that if we have <= _K items, then it's a leaf node, otherwise it's a split node.
     // There's some regrettable complications caused by the problem that root nodes have to be "special":
     // 1. We identify root nodes by the arguable logic that _n_items == n->n_descendants, regardless of how many descendants they actually have
@@ -1210,7 +1220,7 @@ protected:
     }
 
     // If we didn't find a hyperplane, just randomize sides as a last option
-    while (children_indices[0].size() == 0 || children_indices[1].size() == 0) {
+    while (_draw_random_split(children_indices[0], children_indices[1])) {
       if (_verbose)
         showUpdate("\tNo hyperplane found (left has %ld children, right has %ld children)\n",
           children_indices[0].size(), children_indices[1].size());
@@ -1287,7 +1297,7 @@ protected:
     vector<pair<T, S> > nns_dist;
     S last = -1;
     for (size_t i = 0; i < nns.size(); i++) {
-      S j = nns[i];
+      S j = nns[i]; 
       if (j == last)
         continue;
       last = j;


### PR DESCRIPTION
## Issue: #490 

## Functional
- Before: stack-overflow encountered during build on an imbalanced dataset with roughly 10M data
- Now: building passes ok

## Technical
Tree making is a recursion function for which the recursion level wasn't constrained (then linear level `O(N)`). This simple fix is proposed by @erikbern to balance sub-trees a little bit more and control the depth.
This PR does not change the stack-allocation to heap-allocations.

## Tests
Ran the Python unittests. Note that the `accuracy_test.py` failed for 0.01% but it does fail also without thoses changes (is that a known issue?):
```shell
(venv) C:\Workspace\other\annoy\test>python -m unittest accuracy_test.py
                       fashion-mnist-784-euclidean accuracy: 90.65% (expected 90.00%)
.                                  glove-25-angular accuracy: 67.99% (expected 69.00%)
F                                nytimes-16-angular accuracy: 80.81% (expected 80.00%)
.
======================================================================
FAIL: test_glove_25 (accuracy_test.AccuracyTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Workspace\other\annoy\test\accuracy_test.py", line 76, in test_glove_25
    self._test_index('glove-25-angular', 69.00)
  File "C:\Workspace\other\annoy\test\accuracy_test.py", line 73, in _test_index
    self.assertTrue(accuracy > exp_accuracy - 1.0) # should be within 1%
AssertionError: False is not true

----------------------------------------------------------------------
Ran 3 tests in 21.342s

FAILED (failures=1)
```

## ToDo
Function `_make_tree()` could be made iterative to avoid stacking too much and controling in a more fine-grain way the stack size. 
