### PR TITLE
Annoy/make ftruncate work on windows

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -123,6 +123,12 @@ inline void set_error_from_string(char **error, const char* msg) {
 #endif
 #endif
 
+#if !defined(__MINGW32__)
+#define FTRUNCATE_SIZE(x) static_cast<int64_t>(x)
+#else
+#define FTRUNCATE_SIZE(x) (x)
+#endif
+
 
 using std::vector;
 using std::pair;
@@ -910,7 +916,7 @@ public:
       return false;
     }
     _nodes_size = 1;
-    if (ftruncate(_fd, _s * _nodes_size) == -1) {
+    if (ftruncate(_fd, FTRUNCATE_SIZE(_s) * FTRUNCATE_SIZE(_nodes_size)) == -1) {
       set_error_from_errno(error, "Unable to truncate");
       return false;
     }
@@ -963,7 +969,7 @@ public:
     
     if (_on_disk) {
       _nodes = remap_memory(_nodes, _fd, _s * _nodes_size, _s * _n_nodes);
-      if (ftruncate(_fd, _s * _n_nodes)) {
+      if (ftruncate(_fd, FTRUNCATE_SIZE(_s) * FTRUNCATE_SIZE(_n_nodes))) {
         // TODO: this probably creates an index in a corrupt state... not sure what to do
         set_error_from_errno(error, "Unable to truncate");
         return false;
@@ -1145,7 +1151,7 @@ protected:
       void *old = _nodes;
       
       if (_on_disk) {
-        int rc = ftruncate(_fd, _s * new_nodes_size);
+        int rc = ftruncate(_fd, FTRUNCATE_SIZE(_s) * FTRUNCATE_SIZE(new_nodes_size));
         if (_verbose && rc) showUpdate("File truncation error\n");
         _nodes = remap_memory(_nodes, _fd, _s * _nodes_size, _s * new_nodes_size);
       } else {

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -129,24 +129,25 @@ inline void set_error_from_string(char **error, const char* msg) {
 #define FTRUNCATE_SIZE(x) (x)
 #endif
 
-
 using std::vector;
 using std::pair;
 using std::numeric_limits;
 using std::make_pair;
 
-inline void* remap_memory(void* _ptr, int _fd, size_t old_size, size_t new_size) {
+inline bool remap_memory_and_truncate(void** _ptr, int _fd, size_t old_size, size_t new_size) {
 #ifdef __linux__
-  _ptr = mremap(_ptr, old_size, new_size, MREMAP_MAYMOVE);
+    *_ptr = mremap(*_ptr, old_size, new_size, MREMAP_MAYMOVE);
+    bool ok = ftruncate(_fd, new_size) != -1;
 #else
-  munmap(_ptr, old_size);
+    munmap(*_ptr, old_size);
+    bool ok = ftruncate(_fd, FTRUNCATE_SIZE(new_size)) != -1;
 #ifdef MAP_POPULATE
-  _ptr = mmap(_ptr, new_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, _fd, 0);
+    *_ptr = mmap(*_ptr, new_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, _fd, 0);
 #else
-  _ptr = mmap(_ptr, new_size, PROT_READ | PROT_WRITE, MAP_SHARED, _fd, 0);
+    *_ptr = mmap(*_ptr, new_size, PROT_READ | PROT_WRITE, MAP_SHARED, _fd, 0);
 #endif
 #endif
-  return _ptr;
+    return ok;
 }
 
 namespace {
@@ -968,8 +969,9 @@ public:
     if (_verbose) showUpdate("has %d nodes\n", _n_nodes);
     
     if (_on_disk) {
-      _nodes = remap_memory(_nodes, _fd, _s * _nodes_size, _s * _n_nodes);
-      if (ftruncate(_fd, FTRUNCATE_SIZE(_s) * FTRUNCATE_SIZE(_n_nodes))) {
+      if (!remap_memory_and_truncate(&_nodes, _fd,
+          static_cast<size_t>(_s) * static_cast<size_t>(_nodes_size),
+          static_cast<size_t>(_s) * static_cast<size_t>(_n_nodes))) {
         // TODO: this probably creates an index in a corrupt state... not sure what to do
         set_error_from_errno(error, "Unable to truncate");
         return false;
@@ -1151,9 +1153,11 @@ protected:
       void *old = _nodes;
       
       if (_on_disk) {
-        int rc = ftruncate(_fd, FTRUNCATE_SIZE(_s) * FTRUNCATE_SIZE(new_nodes_size));
-        if (_verbose && rc) showUpdate("File truncation error\n");
-        _nodes = remap_memory(_nodes, _fd, _s * _nodes_size, _s * new_nodes_size);
+        if (!remap_memory_and_truncate(&_nodes, _fd, 
+            static_cast<size_t>(_s) * static_cast<size_t>(_nodes_size), 
+            static_cast<size_t>(_s) * static_cast<size_t>(new_nodes_size)) && 
+            _verbose)
+            showUpdate("File truncation error\n");
       } else {
         _nodes = realloc(_nodes, _s * new_nodes_size);
         memset((char *) _nodes + (_nodes_size * _s) / sizeof(char), 0, (new_nodes_size - _nodes_size) * _s);

--- a/src/mman.h
+++ b/src/mman.h
@@ -220,21 +220,21 @@ inline int ftruncate(const int fd, const int64_t size) {
     LARGE_INTEGER li_start, li_size;
     li_start.QuadPart = static_cast<int64_t>(0);
     li_size.QuadPart = size;
-    if (SetFilePointerEx(h, li_start, nullptr, FILE_CURRENT) == ~0 ||
-        SetFilePointerEx(h, li_size, nullptr, FILE_BEGIN) || 
+    if (SetFilePointerEx(h, li_start, NULL, FILE_CURRENT) == ~0 ||
+        SetFilePointerEx(h, li_size, NULL, FILE_BEGIN) == ~0 ||
         !SetEndOfFile(h)) {
-	    const auto error = GetLastError();
+        unsigned long error = GetLastError();
         fprintf(stderr, "I/O error while truncating: %lu\n", error);
         switch (error) {
-	        case ERROR_INVALID_HANDLE:
-	            errno = EBADF;
-	            break;
-	        default:
-	            errno = EIO;
-	            break;
+            case ERROR_INVALID_HANDLE:
+                errno = EBADF;
+                break;
+            default:
+                errno = EIO;
+                break;
         }
         return -1;
-    }
+    }        
     return 0;
 }
 #endif


### PR DESCRIPTION
## Issue: #487 and hopefully #404 and #353 

## Functional
- Before: `ftruncate()` function would crash for big files and `on_disk_build()` also.
- Now: should work 🤞 

## Technical
Change the Windows API calls for more appropriate ones when dealing with large files. Also changed the order of unmap / map / truncate that used to be done while ajusting file size to unmap / truncate / map in order to avoid the ERROR_USER_MAPPED_FILE (1224).

## Tests
- Ran all unit-tests OK
- Used a dataset that used to crash on my Windows-10 (x64) and ensure it does work now.

## Help
I have very restricted access to other OS than Windows right now... It might be good to double-check I did not crash all of the others 😉 

## ToDo
I use `fprintf()` inside `mman.h` which is not redirected to a custom user printer, it might be implemented if need be (though I thought it was useful as a user to have a log of what kind of error occurred in a more readable way than just "I/O error" but did not bother factorizing the logger system to avoid duplicating the macro... ).