### PR TITLE
Add dot product to gowrapper

### DIFF
--- a/src/annoygomodule.h
+++ b/src/annoygomodule.h
@@ -89,4 +89,12 @@ class AnnoyIndexManhattan : public AnnoyIndex {
     this->f = f;
   }
 };
+
+class AnnoyIndexDotProduct : public AnnoyIndex {
+ public:
+  AnnoyIndexDotProduct(int f) {
+    ptr = new ::AnnoyIndex<int32_t, float, ::DotProduct, ::Kiss64Random, AnnoyIndexSingleThreadedBuildPolicy>(f);
+    this->f = f;
+  }
+};
 }

--- a/src/annoygomodule.i
+++ b/src/annoygomodule.i
@@ -91,6 +91,7 @@
 %feature("notabstract") GoAnnoyIndexAngular;
 %feature("notabstract") GoAnnoyIndexEuclidean;
 %feature("notabstract") GoAnnoyIndexManhattan;
+%feature("notabstract") GoAnnoyIndexDotProduct;
 
 
 

--- a/test/annoy_test.go
+++ b/test/annoy_test.go
@@ -206,6 +206,18 @@ func (suite *AnnoyTestSuite) TestGetDistance() {
      annoyindex.DeleteAnnoyIndexAngular(index)
 }
 
+func (suite *AnnoyTestSuite) TestGetDotProductDistance() {
+    index := annoyindex.NewAnnoyIndexDotProduct(2)
+    index.AddItem(0, []float32{0, 1})
+    index.AddItem(1, []float32{1, 1})
+    index.Build(10)
+
+    assert.True(suite.T(),
+        math.Abs(1.0-float64(index.GetDistance(0, 1))) < 0.00001)
+
+    annoyindex.DeleteAnnoyIndexDotProduct(index)
+}
+
 func (suite *AnnoyTestSuite) TestLargeEuclideanIndex() {
      index := annoyindex.NewAnnoyIndexEuclidean(10)
 


### PR DESCRIPTION
Add the necessary classes so golang can use the dot product distance.