### PR TITLE
Use the default seed from Random to reproduce historical results.

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -874,7 +874,7 @@ protected:
   S _nodes_size;
   vector<S> _roots;
   S _K;
-  R _seed = Random::default_seed;
+  R _seed;
   bool _loaded;
   bool _verbose;
   int _fd;
@@ -882,7 +882,7 @@ protected:
   bool _built;
 public:
 
-   AnnoyIndex(int f) : _f(f) {
+   AnnoyIndex(int f) : _f(f), _seed(Random::default_seed) {
     _s = offsetof(Node, v) + _f * sizeof(T); // Size of each node
     _verbose = false;
     _built = false;

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -57,7 +57,10 @@ typedef signed __int64    int64_t;
 #include <algorithm>
 #include <queue>
 #include <limits>
+
+#if __cplusplus >= 201103L
 #include <type_traits>
+#endif
 
 #ifdef ANNOYLIB_MULTITHREADED_BUILD
 #include <thread>
@@ -839,7 +842,13 @@ class AnnoyIndexInterface {
 };
 
 template<typename S, typename T, typename Distance, typename Random, class ThreadedBuildPolicy>
-  class AnnoyIndex : public AnnoyIndexInterface<S, T, typename std::remove_const<decltype(Random::default_seed)>::type> {
+  class AnnoyIndex : public AnnoyIndexInterface<S, T, 
+#if __cplusplus >= 201103L
+    typename std::remove_const<decltype(Random::default_seed)>::type
+#else
+    typename Random::seed_type
+#endif
+    > {
   /*
    * We use random projection to build a forest of binary trees of all items.
    * Basically just split the hyperspace into two sides by a hyperplane,
@@ -850,7 +859,11 @@ template<typename S, typename T, typename Distance, typename Random, class Threa
 public:
   typedef Distance D;
   typedef typename D::template Node<S, T> Node;
+#if __cplusplus >= 201103L
   typedef typename std::remove_const<decltype(Random::default_seed)>::type R;
+#else
+  typedef Random::seed_type R;
+#endif
 
 protected:
   const int _f;

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -57,6 +57,7 @@ typedef signed __int64    int64_t;
 #include <algorithm>
 #include <queue>
 #include <limits>
+#include <type_traits>
 
 #ifdef ANNOYLIB_MULTITHREADED_BUILD
 #include <thread>
@@ -815,7 +816,7 @@ struct Manhattan : Minkowski {
   }
 };
 
-template<typename S, typename T>
+template<typename S, typename T, typename R = uint64_t>
 class AnnoyIndexInterface {
  public:
   // Note that the methods with an **error argument will allocate memory and write the pointer to that string if error is non-NULL
@@ -833,12 +834,12 @@ class AnnoyIndexInterface {
   virtual S get_n_trees() const = 0;
   virtual void verbose(bool v) = 0;
   virtual void get_item(S item, T* v) const = 0;
-  virtual void set_seed(int q) = 0;
+  virtual void set_seed(R q) = 0;
   virtual bool on_disk_build(const char* filename, char** error=NULL) = 0;
 };
 
 template<typename S, typename T, typename Distance, typename Random, class ThreadedBuildPolicy>
-  class AnnoyIndex : public AnnoyIndexInterface<S, T> {
+  class AnnoyIndex : public AnnoyIndexInterface<S, T, typename std::remove_const<decltype(Random::default_seed)>::type> {
   /*
    * We use random projection to build a forest of binary trees of all items.
    * Basically just split the hyperspace into two sides by a hyperplane,
@@ -849,6 +850,7 @@ template<typename S, typename T, typename Distance, typename Random, class Threa
 public:
   typedef Distance D;
   typedef typename D::template Node<S, T> Node;
+  typedef typename std::remove_const<decltype(Random::default_seed)>::type R;
 
 protected:
   const int _f;
@@ -859,8 +861,7 @@ protected:
   S _nodes_size;
   vector<S> _roots;
   S _K;
-  bool _is_seeded;
-  int _seed;
+  R _seed = Random::default_seed;
   bool _loaded;
   bool _verbose;
   int _fd;
@@ -1027,7 +1028,7 @@ public:
     _n_nodes = 0;
     _nodes_size = 0;
     _on_disk = false;
-    _is_seeded = false;
+    _seed = Random::default_seed;
     _roots.clear();
   }
 
@@ -1134,16 +1135,13 @@ public:
     memcpy(v, m->v, (_f) * sizeof(T));
   }
 
-  void set_seed(int seed) {
-    _is_seeded = true;
+  void set_seed(R seed) {
     _seed = seed;
   }
 
   void thread_build(int q, int thread_idx, ThreadedBuildPolicy& threaded_build_policy) {
-    Random _random;
     // Each thread needs its own seed, otherwise each thread would be building the same tree(s)
-    int seed = _is_seeded ? _seed + thread_idx : thread_idx;
-    _random.set_seed(seed);
+    Random _random(_seed + thread_idx);
 
     vector<S> thread_roots;
     while (1) {

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -862,7 +862,7 @@ public:
 #if __cplusplus >= 201103L
   typedef typename std::remove_const<decltype(Random::default_seed)>::type R;
 #else
-  typedef Random::seed_type R;
+  typedef typename Random::seed_type R;
 #endif
 
 protected:

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -123,7 +123,7 @@ public:
     _index.get_item(item, &v_internal[0]);
     _unpack(&v_internal[0], v);
   };
-  void set_seed(int q) { _index.set_seed(q); };
+  void set_seed(uint64_t q) { _index.set_seed(q); };
   bool on_disk_build(const char* filename, char** error) { return _index.on_disk_build(filename, error); };
 };
 

--- a/src/kissrandom.h
+++ b/src/kissrandom.h
@@ -21,6 +21,9 @@ struct Kiss32Random {
   uint32_t c;
 
   static const uint32_t default_seed = 123456789;
+#if __cplusplus < 201103L
+  typedef uint32_t seed_type;
+#endif
 
   // seed must be != 0
   Kiss32Random(uint32_t seed = default_seed) {
@@ -67,6 +70,9 @@ struct Kiss64Random {
   uint64_t c;
 
   static const uint64_t default_seed = 1234567890987654321ULL;
+#if __cplusplus < 201103L
+  typedef uint64_t seed_type;
+#endif
 
   // seed must be != 0
   Kiss64Random(uint64_t seed = default_seed) {

--- a/src/kissrandom.h
+++ b/src/kissrandom.h
@@ -20,8 +20,10 @@ struct Kiss32Random {
   uint32_t z;
   uint32_t c;
 
+  static const uint32_t default_seed = 123456789;
+
   // seed must be != 0
-  Kiss32Random(uint32_t seed = 123456789) {
+  Kiss32Random(uint32_t seed = default_seed) {
     x = seed;
     y = 362436000;
     z = 521288629;
@@ -64,8 +66,10 @@ struct Kiss64Random {
   uint64_t z;
   uint64_t c;
 
+  static const uint64_t default_seed = 1234567890987654321ULL;
+
   // seed must be != 0
-  Kiss64Random(uint64_t seed = 1234567890987654321ULL) {
+  Kiss64Random(uint64_t seed = default_seed) {
     x = seed;
     y = 362436362436362436ULL;
     z = 1066149217761810ULL;
@@ -97,7 +101,7 @@ struct Kiss64Random {
     // Draw random integer between 0 and n-1 where n is at most the number of data points you have
     return kiss() % n;
   }
-  inline void set_seed(uint32_t seed) {
+  inline void set_seed(uint64_t seed) {
     x = seed;
   }
 };

--- a/test/seed_test.py
+++ b/test/seed_test.py
@@ -15,7 +15,12 @@
 import numpy
 from common import TestCase
 from annoy import AnnoyIndex
-
+import os
+import h5py
+try:
+    from urllib import urlretrieve
+except ImportError:
+    from urllib.request import urlretrieve # Python 3
 
 class SeedTest(TestCase):
     def test_seeding(self):
@@ -36,4 +41,49 @@ class SeedTest(TestCase):
         for k in range(Y.shape[0]):
             self.assertEquals(indexes[0].get_nns_by_vector(Y[k], 100),
                               indexes[1].get_nns_by_vector(Y[k], 100))
+
+    def test_historical(self):
+        dataset = "fashion-mnist-784-euclidean"
+        url = 'http://vectors.erikbern.com/%s.hdf5' % dataset
+        vectors_fn = os.path.join('test', dataset + '.hdf5')
+        if not os.path.exists(vectors_fn):
+            urlretrieve(url, vectors_fn)
+
+        dataset_f = h5py.File(vectors_fn, 'r')
+        f = dataset_f['train'].shape[1]
+
+        # Round 1, checking that we recover historical results with the default seed.
+        annoy = AnnoyIndex(f, 'euclidean')
+        for i, v in enumerate(dataset_f['train']):
+            annoy.add_item(i, v)
+
+        annoy.build(10)
+        self.assertEquals(annoy.get_nns_by_item(0, 10),
+                          [0, 27655, 18247, 9936, 48748, 26244, 49961, 38909, 55767, 38152])
+        self.assertEquals(annoy.get_nns_by_item(10, 10),
+                          [10, 48474, 15493, 18055, 54960, 32003, 13842, 24831, 24497, 26585])
+        self.assertEquals(annoy.get_nns_by_item(100, 10),
+                          [100, 19840, 28600, 4270, 49340, 38437, 26777, 57981, 25662, 46624])
+        self.assertEquals(annoy.get_nns_by_item(1000, 10),
+                          [1000, 55577, 20213, 379, 17810, 12464, 35858, 53879, 56078, 25054])
+        self.assertEquals(annoy.get_nns_by_item(10000, 10),
+                          [10000, 46719, 50444, 15672, 36818, 30426, 4374, 58080, 10938, 25192])
+
+        # Round 2, checking that changing the seed actually does have an effect.
+        annoy2 = AnnoyIndex(f, 'euclidean')
+        for i, v in enumerate(dataset_f['train']):
+            annoy2.add_item(i, v)
+
+        annoy2.set_seed(0)
+        annoy2.build(10)
+        self.assertEquals(annoy2.get_nns_by_item(0, 10),
+                          [0, 25719, 27655, 55310, 18247, 9936, 48748, 49961, 35683, 47527])
+        self.assertEquals(annoy2.get_nns_by_item(10, 10),
+                          [10, 48474, 15493, 18055, 54960, 32003, 14603, 13842, 24831, 24497])
+        self.assertEquals(annoy2.get_nns_by_item(100, 10),
+                          [100, 19840, 28600, 4270, 49340, 38437, 26777, 57981, 52911, 25662])
+        self.assertEquals(annoy2.get_nns_by_item(1000, 10),
+                          [1000, 55577, 20213, 379, 17810, 35858, 53879, 56078, 25054, 20816])
+        self.assertEquals(annoy2.get_nns_by_item(10000, 10),
+                          [10000, 50444, 15672, 36818, 30426, 4374, 58080, 25192, 47437, 25348])
 

--- a/test/seed_test.py
+++ b/test/seed_test.py
@@ -15,12 +15,7 @@
 import numpy
 from common import TestCase
 from annoy import AnnoyIndex
-import os
-import h5py
-try:
-    from urllib import urlretrieve
-except ImportError:
-    from urllib.request import urlretrieve # Python 3
+
 
 class SeedTest(TestCase):
     def test_seeding(self):
@@ -41,49 +36,4 @@ class SeedTest(TestCase):
         for k in range(Y.shape[0]):
             self.assertEquals(indexes[0].get_nns_by_vector(Y[k], 100),
                               indexes[1].get_nns_by_vector(Y[k], 100))
-
-    def test_historical(self):
-        dataset = "fashion-mnist-784-euclidean"
-        url = 'http://vectors.erikbern.com/%s.hdf5' % dataset
-        vectors_fn = os.path.join('test', dataset + '.hdf5')
-        if not os.path.exists(vectors_fn):
-            urlretrieve(url, vectors_fn)
-
-        dataset_f = h5py.File(vectors_fn, 'r')
-        f = dataset_f['train'].shape[1]
-
-        # Round 1, checking that we recover historical results with the default seed.
-        annoy = AnnoyIndex(f, 'euclidean')
-        for i, v in enumerate(dataset_f['train']):
-            annoy.add_item(i, v)
-
-        annoy.build(10)
-        self.assertEquals(annoy.get_nns_by_item(0, 10),
-                          [0, 27655, 18247, 9936, 48748, 26244, 49961, 38909, 55767, 38152])
-        self.assertEquals(annoy.get_nns_by_item(10, 10),
-                          [10, 48474, 15493, 18055, 54960, 32003, 13842, 24831, 24497, 26585])
-        self.assertEquals(annoy.get_nns_by_item(100, 10),
-                          [100, 19840, 28600, 4270, 49340, 38437, 26777, 57981, 25662, 46624])
-        self.assertEquals(annoy.get_nns_by_item(1000, 10),
-                          [1000, 55577, 20213, 379, 17810, 12464, 35858, 53879, 56078, 25054])
-        self.assertEquals(annoy.get_nns_by_item(10000, 10),
-                          [10000, 46719, 50444, 15672, 36818, 30426, 4374, 58080, 10938, 25192])
-
-        # Round 2, checking that changing the seed actually does have an effect.
-        annoy2 = AnnoyIndex(f, 'euclidean')
-        for i, v in enumerate(dataset_f['train']):
-            annoy2.add_item(i, v)
-
-        annoy2.set_seed(0)
-        annoy2.build(10)
-        self.assertEquals(annoy2.get_nns_by_item(0, 10),
-                          [0, 25719, 27655, 55310, 18247, 9936, 48748, 49961, 35683, 47527])
-        self.assertEquals(annoy2.get_nns_by_item(10, 10),
-                          [10, 48474, 15493, 18055, 54960, 32003, 14603, 13842, 24831, 24497])
-        self.assertEquals(annoy2.get_nns_by_item(100, 10),
-                          [100, 19840, 28600, 4270, 49340, 38437, 26777, 57981, 52911, 25662])
-        self.assertEquals(annoy2.get_nns_by_item(1000, 10),
-                          [1000, 55577, 20213, 379, 17810, 35858, 53879, 56078, 25054, 20816])
-        self.assertEquals(annoy2.get_nns_by_item(10000, 10),
-                          [10000, 50444, 15672, 36818, 30426, 4374, 58080, 25192, 47437, 25348])
 


### PR DESCRIPTION
It seems that the latest Annoy library (in single-threaded mode) yields different results to the previous version, due to a change in the seed used for tree construction. The previous Annoy version initialized `Random` with its default seed, while the current version effectively sets it to zero without manual intervention:

https://github.com/spotify/annoy/blob/ce7d76770537d4ca78dd59f4f34571aa7631ff11/src/annoylib.h#L1144-L1146

(i.e., if I don't call `set_seed()` somewhere along the line, and I use the single-threaded policy, then `_seed` ends up being zero due to `_is_seeded=false` and `thread_idx=0`.)

This change is a bit - ahem - annoying for scientific applications where we would like to be able to reproduce the result of computational workflows. I mean, I get it, sometimes algorithms have to change and that different results are unavoidable; but in this case, the change does not seem necessary. One seed is as good as any other, and the old seed does look, at least, a bit better than just a flat zero.

This PR modifies the Annoy C++ library to recover the old results by ensuring that - for single-threaded applications - we are using the `Random`'s default seed. It modifies a few interfaces to ensure that the user can actually pass large `uint`s to `Random` without truncation to `int`. Furthermore, we streamline the class a little by removing the need for the `is_seeded` indicator.

Some notes:

- Apologies for the clunky type detection, I couldn't figure out a more succint way to do that. 
- The new template parameter for `AnnoyIndexInterface` defaults to `uint64_t` under the assumption that most people are using `Kiss64Random` and thus any C++ code referring to `AnnoyIndexInterface`s (e.g., in pointers to the base class) should continue to work.
- Classes for `Random` now have the extra requirement that a `default_seed` variable be present. This may affect some users who are passing in their own PRNGs.
- Wasn't quite sure what to do with the Python wrapper around `set_seed`, which effectively truncates to `int`. **RcppAnnoy** has the same problem.

https://github.com/spotify/annoy/blob/ce7d76770537d4ca78dd59f4f34571aa7631ff11/src/annoymodule.cc#L515-L525

Further context on this problem can be found in jlmelville/uwot#69.
