### PR TITLE
improve error handling for vectors

### DIFF
--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -301,7 +301,7 @@ py_an_get_nns_by_item(py_annoy *self, PyObject *args, PyObject *kwargs) {
 
 
 bool
-convert_iterable_to_vector(PyObject* v, int f, vector<float>* w) {
+convert_list_to_vector(PyObject* v, int f, vector<float>* w) {
   Py_ssize_t length = PyObject_Size(v);
   if (length == -1) {
     return false;
@@ -311,30 +311,14 @@ convert_iterable_to_vector(PyObject* v, int f, vector<float>* w) {
     return false;
   }
 
-  PyObject *iterator = PyObject_GetIter(v);
-  PyObject *item;
-
-  if (iterator == NULL) {
     return false;
   }
   for (int z = 0; z < f; z++) {
-    item = PyIter_Next(iterator);
-
-    if (item == NULL) {
-      PyErr_Format(PyExc_IndexError, "Vector has wrong length (expected %d, got %d)", f, z);
-      return false;
-    }
-
-    double value = PyFloat_AsDouble(item);
-    Py_DECREF(item);
-    if (value == -1.0 && PyErr_Occurred()) {
-      return false;
-    }
-    (*w)[z] = value;
-  }
-  Py_DECREF(iterator);
-  if (PyErr_Occurred()) {
-    return false;
+    PyObject *key = PyInt_FromLong(z);
+    PyObject *pf = PyObject_GetItem(v, key);
+    (*w)[z] = PyFloat_AsDouble(pf);
+    Py_DECREF(key);
+    Py_DECREF(pf);
   }
   return true;
 }
@@ -351,7 +335,7 @@ py_an_get_nns_by_vector(py_annoy *self, PyObject *args, PyObject *kwargs) {
     return NULL;
 
   vector<float> w(self->f);
-  if (!convert_iterable_to_vector(v, self->f, &w)) {
+  if (!convert_list_to_vector(v, self->f, &w)) {
     return NULL;
   }
 
@@ -407,7 +391,7 @@ py_an_add_item(py_annoy *self, PyObject *args, PyObject* kwargs) {
   }
 
   vector<float> w(self->f);
-  if (!convert_iterable_to_vector(v, self->f, &w)) {
+  if (!convert_list_to_vector(v, self->f, &w)) {
     return NULL;
   }
   char* error;

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -237,16 +237,25 @@ py_an_save(py_annoy *self, PyObject *args, PyObject *kwargs) {
 PyObject*
 get_nns_to_python(const vector<int32_t>& result, const vector<float>& distances, int include_distances) {
   PyObject* l = PyList_New(result.size());
+  if (l == NULL) {
+    return NULL;
+  }
   for (size_t i = 0; i < result.size(); i++)
     PyList_SetItem(l, i, PyInt_FromLong(result[i]));
   if (!include_distances)
     return l;
 
   PyObject* d = PyList_New(distances.size());
+  if (d == NULL) {
+    return NULL;
+  }
   for (size_t i = 0; i < distances.size(); i++)
     PyList_SetItem(d, i, PyFloat_FromDouble(distances[i]));
 
   PyObject* t = PyTuple_New(2);
+  if (t == NULL) {
+    return NULL;
+  }
   PyTuple_SetItem(t, 0, l);
   PyTuple_SetItem(t, 1, d);
 
@@ -372,6 +381,9 @@ py_an_get_item_vector(py_annoy *self, PyObject *args) {
   vector<float> v(self->f);
   self->ptr->get_item(item, &v[0]);
   PyObject* l = PyList_New(self->f);
+  if (l == NULL) {
+    return NULL;
+  }
   for (int z = 0; z < self->f; z++) {
     PyList_SetItem(l, z, PyFloat_FromDouble(v[z]));
   }

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -311,8 +311,6 @@ convert_list_to_vector(PyObject* v, int f, vector<float>* w) {
     return false;
   }
 
-    return false;
-  }
   for (int z = 0; z < f; z++) {
     PyObject *key = PyInt_FromLong(z);
     PyObject *pf = PyObject_GetItem(v, key);

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -326,6 +326,9 @@ convert_iterable_to_vector(PyObject* v, int f, vector<float>* w) {
     (*w)[z] = value;
   }
   Py_DECREF(iterator);
+  if (PyErr_Occurred()) {
+    return false;
+  }
   return true;
 }
 

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -295,7 +295,6 @@ bool
 convert_iterable_to_vector(PyObject* v, int f, vector<float>* w) {
   Py_ssize_t length = PyObject_Size(v);
   if (length == -1) {
-    PyErr_Format(PyExc_TypeError, "object of type '%.200s' has no len()", Py_TYPE(v)->tp_name);
     return false;
   }
   if (length != f) {
@@ -307,7 +306,6 @@ convert_iterable_to_vector(PyObject* v, int f, vector<float>* w) {
   PyObject *item;
 
   if (iterator == NULL) {
-    PyErr_Format(PyExc_TypeError, "'%.200s' object is not iterable", Py_TYPE(v)->tp_name);
     return false;
   }
   for (int z = 0; z < f; z++) {

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -313,10 +313,20 @@ convert_list_to_vector(PyObject* v, int f, vector<float>* w) {
 
   for (int z = 0; z < f; z++) {
     PyObject *key = PyInt_FromLong(z);
+    if (key == NULL) {
+      return false;
+    }
     PyObject *pf = PyObject_GetItem(v, key);
-    (*w)[z] = PyFloat_AsDouble(pf);
     Py_DECREF(key);
+    if (pf == NULL) {
+      return false;
+    }
+    double value = PyFloat_AsDouble(pf);
     Py_DECREF(pf);
+    if (value == -1.0 && PyErr_Occurred()) {
+      return false;
+    }
+    (*w)[z] = value;
   }
   return true;
 }

--- a/test/types_test.py
+++ b/test/types_test.py
@@ -13,6 +13,7 @@
 # the License.
 
 import numpy
+import sys
 import random
 from common import TestCase
 from annoy import AnnoyIndex
@@ -66,8 +67,13 @@ class TypesTest(TestCase):
             pass
         
         i = AnnoyIndex(10, 'euclidean')
-        with self.assertRaises(TypeError, msg="object of type 'FakeCollection' has no len()"):
-            i.add_item(1, FakeCollection())
+        # Python 2.7 raises an AttributeError instead of a TypeError like newer versions of Python.
+        if sys.version_info.major == 2:
+            with self.assertRaises(AttributeError, msg="FakeCollection instance has no attribute '__len__'"):
+                i.add_item(1, FakeCollection())
+        else:
+            with self.assertRaises(TypeError, msg="object of type 'FakeCollection' has no len()"):
+                i.add_item(1, FakeCollection())
 
     def test_missing_getitem(self):
         """
@@ -79,8 +85,13 @@ class TypesTest(TestCase):
                 return 5
         
         i = AnnoyIndex(5, 'euclidean')
-        with self.assertRaises(TypeError, msg="'FakeCollection' object is not subscriptable"):
-            i.add_item(1, FakeCollection())
+        # Python 2.7 raises an AttributeError instead of a TypeError like newer versions of Python.
+        if sys.version_info.major == 2:
+            with self.assertRaises(AttributeError, msg="FakeCollection instance has no attribute '__getitem__'"):
+                i.add_item(1, FakeCollection())
+        else:
+            with self.assertRaises(TypeError, msg="'FakeCollection' object is not subscriptable"):
+                i.add_item(1, FakeCollection())
 
     def test_short(self):
         """

--- a/test/types_test.py
+++ b/test/types_test.py
@@ -90,7 +90,7 @@ class TypesTest(TestCase):
             def __len__(self):
                 return 3
             
-            def __getitem__(self, i: int) -> float:
+            def __getitem__(self, i):
                 raise IndexError 
         
         i = AnnoyIndex(3, 'euclidean')

--- a/test/types_test.py
+++ b/test/types_test.py
@@ -69,20 +69,20 @@ class TypesTest(TestCase):
         with self.assertRaises(TypeError, msg="object of type 'FakeCollection' has no len()"):
             i.add_item(1, FakeCollection())
 
-    def test_missing_iter(self):
+    def test_missing_getitem(self):
         """
         We should get a helpful error message if our vector doesn't have a
-        __iter__ method.
+        __getitem__ method.
         """
         class FakeCollection:
             def __len__(self):
                 return 5
         
         i = AnnoyIndex(5, 'euclidean')
-        with self.assertRaises(TypeError, msg="'FakeCollection' object is not iterable"):
+        with self.assertRaises(TypeError, msg="'FakeCollection' object is not subscriptable"):
             i.add_item(1, FakeCollection())
 
-    def test_short_iter(self):
+    def test_short(self):
         """
         Ensure we handle our vector not being long enough.
         """
@@ -90,11 +90,11 @@ class TypesTest(TestCase):
             def __len__(self):
                 return 3
             
-            def __iter__(self):
-                return iter([1,2])
+            def __getitem__(self, i: int) -> float:
+                raise IndexError 
         
         i = AnnoyIndex(3, 'euclidean')
-        with self.assertRaises(IndexError, msg="Vector has wrong length (expected 3, got 2)"):
+        with self.assertRaises(IndexError):
             i.add_item(1, FakeCollection())
     
     def test_non_float(self):

--- a/test/types_test.py
+++ b/test/types_test.py
@@ -64,7 +64,7 @@ class TypesTest(TestCase):
         __len__ method.
         """
         class FakeCollection:
-            ...
+            pass
         
         i = AnnoyIndex(10, 'euclidean')
         with self.assertRaises(TypeError, msg="object of type 'FakeCollection' has no len()"):

--- a/test/types_test.py
+++ b/test/types_test.py
@@ -12,7 +12,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from typing import Type
 import numpy
 import random
 from common import TestCase


### PR DESCRIPTION
Annoy now better handles invalid vectors.

We now use Python's default error formatting when a vector doesn't have a `__len__` method. We also check the return types for functions like `PyObject_GetItem` and `PyFloat_AsDouble` so we gracefully handle errors.

fixes #531
fixes #546