### PR TITLE
Support CMake-based dependency resolution in C++ projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,20 @@
+cmake_minimum_required(VERSION 3.14)
 project(Annoy
     DESCRIPTION "Approximate Nearest Neighbors Oh Yeah"
     VERSION 1.17.0
     LANGUAGES CXX
 )
-cmake_minimum_required(VERSION 3.14)
 
 add_library(Annoy INTERFACE)
 
-target_include_directories(Annoy INTERFACE src/)
+set(ANNOY_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include/annoy)
+file(MAKE_DIRECTORY ${ANNOY_INCLUDE_DIR})
+foreach (HEADER annoylib.h kissrandom.h mman.h)
+    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/src/${HEADER} 
+         DESTINATION ${ANNOY_INCLUDE_DIR}/${HEADER})
+endforeach()
+
+target_include_directories(Annoy INTERFACE include/)
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     # Add Python set-up code here.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,7 @@ add_library(Annoy INTERFACE)
 set(ANNOY_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include/annoy)
 file(MAKE_DIRECTORY ${ANNOY_INCLUDE_DIR})
 foreach (HEADER annoylib.h kissrandom.h mman.h)
-    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/src/${HEADER} 
-         DESTINATION ${ANNOY_INCLUDE_DIR}/${HEADER})
+    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/src/${HEADER} DESTINATION ${ANNOY_INCLUDE_DIR})
 endforeach()
 
 target_include_directories(Annoy INTERFACE include/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+project(Annoy
+    DESCRIPTION "Approximate Nearest Neighbors Oh Yeah"
+    VERSION 1.17.0
+    LANGUAGES CXX
+)
+cmake_minimum_required(VERSION 3.14)
+
+add_library(Annoy INTERFACE)
+
+target_include_directories(Annoy INTERFACE src/)
+
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    # Add Python set-up code here.
+endif()
+

--- a/src/annoygomodule.h
+++ b/src/annoygomodule.h
@@ -1,6 +1,8 @@
 #include "annoylib.h"
 #include "kissrandom.h"
 
+using namespace Annoy;
+
 namespace GoAnnoy {
 
 class AnnoyIndex {

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -13,8 +13,8 @@
 // the License.
 
 
-#ifndef ANNOYLIB_H
-#define ANNOYLIB_H
+#ifndef ANNOY_ANNOYLIB_H
+#define ANNOY_ANNOYLIB_H
 
 #include <stdio.h>
 #include <sys/stat.h>
@@ -76,9 +76,9 @@ typedef signed __int64    int64_t;
 // This allows others to supply their own logger / error printer without
 // requiring Annoy to import their headers. See RcppAnnoy for a use case.
 #ifndef __ERROR_PRINTER_OVERRIDE__
-  #define showUpdate(...) { fprintf(stderr, __VA_ARGS__ ); }
+  #define Annoy_showUpdate(...) { fprintf(stderr, __VA_ARGS__ ); }
 #else
-  #define showUpdate(...) { __ERROR_PRINTER_OVERRIDE__( __VA_ARGS__ ); }
+  #define Annoy_showUpdate(...) { __ERROR_PRINTER_OVERRIDE__( __VA_ARGS__ ); }
 #endif
 
 // Portable alloc definition, cf Writing R Extensions, Section 1.6.4
@@ -91,40 +91,24 @@ typedef signed __int64    int64_t;
   # include <alloca.h>
 #endif
 
-inline void set_error_from_errno(char **error, const char* msg) {
-  showUpdate("%s: %s (%d)\n", msg, strerror(errno), errno);
-  if (error) {
-    *error = (char *)malloc(256);  // TODO: win doesn't support snprintf
-    sprintf(*error, "%s: %s (%d)", msg, strerror(errno), errno);
-  }
-}
-
-inline void set_error_from_string(char **error, const char* msg) {
-  showUpdate("%s\n", msg);
-  if (error) {
-    *error = (char *)malloc(strlen(msg) + 1);
-    strcpy(*error, msg);
-  }
-}
-
 // We let the v array in the Node struct take whatever space is needed, so this is a mostly insignificant number.
 // Compilers need *some* size defined for the v array, and some memory checking tools will flag for buffer overruns if this is set too low.
-#define V_ARRAY_SIZE 65536
+#define ANNOY_V_ARRAY_SIZE 65536
 
 #ifndef _MSC_VER
-#define popcount __builtin_popcountll
+#define Annoy_popcount __builtin_popcountll
 #else // See #293, #358
-#define popcount cole_popcount
+#define Annoy_popcount cole_popcount
 #endif
 
 #if !defined(NO_MANUAL_VECTORIZATION) && defined(__GNUC__) && (__GNUC__ >6) && defined(__AVX512F__)  // See #402
-#define USE_AVX512
+#define ANNOY_USE_AVX512
 #elif !defined(NO_MANUAL_VECTORIZATION) && defined(__AVX__) && defined (__SSE__) && defined(__SSE2__) && defined(__SSE3__)
-#define USE_AVX
+#define ANNOY_USE_AVX
 #else
 #endif
 
-#if defined(USE_AVX) || defined(USE_AVX512)
+#if defined(ANNOY_USE_AVX) || defined(ANNOY_USE_AVX512)
 #if defined(_MSC_VER)
 #include <intrin.h>
 #elif defined(__GNUC__)
@@ -133,10 +117,29 @@ inline void set_error_from_string(char **error, const char* msg) {
 #endif
 
 #if !defined(__MINGW32__)
-#define FTRUNCATE_SIZE(x) static_cast<int64_t>(x)
+#define ANNOY_FTRUNCATE_SIZE(x) static_cast<int64_t>(x)
 #else
-#define FTRUNCATE_SIZE(x) (x)
+#define ANNOY_FTRUNCATE_SIZE(x) (x)
 #endif
+
+namespace Annoy {
+
+inline void set_error_from_errno(char **error, const char* msg) {
+  Annoy_showUpdate("%s: %s (%d)\n", msg, strerror(errno), errno);
+  if (error) {
+    *error = (char *)malloc(256);  // TODO: win doesn't support snprintf
+    sprintf(*error, "%s: %s (%d)", msg, strerror(errno), errno);
+  }
+}
+
+inline void set_error_from_string(char **error, const char* msg) {
+  Annoy_showUpdate("%s\n", msg);
+  if (error) {
+    *error = (char *)malloc(strlen(msg) + 1);
+    strcpy(*error, msg);
+  }
+}
+
 
 using std::vector;
 using std::pair;
@@ -149,7 +152,7 @@ inline bool remap_memory_and_truncate(void** _ptr, int _fd, size_t old_size, siz
     bool ok = ftruncate(_fd, new_size) != -1;
 #else
     munmap(*_ptr, old_size);
-    bool ok = ftruncate(_fd, FTRUNCATE_SIZE(new_size)) != -1;
+    bool ok = ftruncate(_fd, ANNOY_FTRUNCATE_SIZE(new_size)) != -1;
 #ifdef MAP_POPULATE
     *_ptr = mmap(*_ptr, new_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, _fd, 0);
 #else
@@ -198,7 +201,7 @@ inline T euclidean_distance(const T* x, const T* y, int f) {
   return d;
 }
 
-#ifdef USE_AVX
+#ifdef ANNOY_USE_AVX
 // Horizontal single sum of 256bit vector.
 inline float hsum256_ps_avx(__m256 v) {
   const __m128 x128 = _mm_add_ps(_mm256_extractf128_ps(v, 1), _mm256_castps256_ps128(v));
@@ -281,7 +284,7 @@ inline float euclidean_distance<float>(const float* x, const float* y, int f) {
 
 #endif
 
-#ifdef USE_AVX512
+#ifdef ANNOY_USE_AVX512
 template<>
 inline float dot<float>(const float* x, const float *y, int f) {
   float result = 0;
@@ -456,7 +459,7 @@ struct Angular : Base {
       S children[2]; // Will possibly store more than 2
       T norm;
     };
-    T v[V_ARRAY_SIZE];
+    T v[ANNOY_V_ARRAY_SIZE];
   };
   template<typename S, typename T>
   static inline T distance(const Node<S, T>* x, const Node<S, T>* y, int f) {
@@ -527,7 +530,7 @@ struct DotProduct : Angular {
     S n_descendants;
     S children[2]; // Will possibly store more than 2
     T dot_factor;
-    T v[V_ARRAY_SIZE];
+    T v[ANNOY_V_ARRAY_SIZE];
   };
 
   static const char* name() {
@@ -634,7 +637,7 @@ struct Hamming : Base {
   struct Node {
     S n_descendants;
     S children[2];
-    T v[V_ARRAY_SIZE];
+    T v[ANNOY_V_ARRAY_SIZE];
   };
 
   static const size_t max_iterations = 20;
@@ -663,7 +666,7 @@ struct Hamming : Base {
   static inline T distance(const Node<S, T>* x, const Node<S, T>* y, int f) {
     size_t dist = 0;
     for (int i = 0; i < f; i++) {
-      dist += popcount(x->v[i] ^ y->v[i]);
+      dist += Annoy_popcount(x->v[i] ^ y->v[i]);
     }
     return dist;
   }
@@ -731,7 +734,7 @@ struct Minkowski : Base {
     S n_descendants;
     T a; // need an extra constant term to determine the offset of the plane
     S children[2];
-    T v[V_ARRAY_SIZE];
+    T v[ANNOY_V_ARRAY_SIZE];
   };
   template<typename S, typename T>
   static inline T margin(const Node<S, T>* n, const T* y, int f) {
@@ -936,7 +939,7 @@ public:
       return false;
     }
     _nodes_size = 1;
-    if (ftruncate(_fd, FTRUNCATE_SIZE(_s) * FTRUNCATE_SIZE(_nodes_size)) == -1) {
+    if (ftruncate(_fd, ANNOY_FTRUNCATE_SIZE(_s) * ANNOY_FTRUNCATE_SIZE(_nodes_size)) == -1) {
       set_error_from_errno(error, "Unable to truncate");
       return false;
     }
@@ -972,7 +975,7 @@ public:
       memcpy(_get(_n_nodes + (S)i), _get(_roots[i]), _s);
     _n_nodes += _roots.size();
 
-    if (_verbose) showUpdate("has %d nodes\n", _n_nodes);
+    if (_verbose) Annoy_showUpdate("has %d nodes\n", _n_nodes);
     
     if (_on_disk) {
       if (!remap_memory_and_truncate(&_nodes, _fd,
@@ -1060,7 +1063,7 @@ public:
       }
     }
     reinitialize();
-    if (_verbose) showUpdate("unloaded\n");
+    if (_verbose) Annoy_showUpdate("unloaded\n");
   }
 
   bool load(const char* filename, bool prefault=false, char** error=NULL) {
@@ -1088,7 +1091,7 @@ public:
 #ifdef MAP_POPULATE
       flags |= MAP_POPULATE;
 #else
-      showUpdate("prefault is set to true, but MAP_POPULATE is not defined on this platform");
+      Annoy_showUpdate("prefault is set to true, but MAP_POPULATE is not defined on this platform");
 #endif
     }
     _nodes = (Node*)mmap(0, size, PROT_READ, flags, _fd, 0);
@@ -1112,7 +1115,7 @@ public:
     _loaded = true;
     _built = true;
     _n_items = m;
-    if (_verbose) showUpdate("found %lu roots with degree %d\n", _roots.size(), m);
+    if (_verbose) Annoy_showUpdate("found %lu roots with degree %d\n", _roots.size(), m);
     return true;
   }
 
@@ -1171,7 +1174,7 @@ public:
         }
       }
 
-      if (_verbose) showUpdate("pass %zd...\n", thread_roots.size());
+      if (_verbose) Annoy_showUpdate("pass %zd...\n", thread_roots.size());
 
       vector<S> indices;
       threaded_build_policy.lock_shared_nodes();
@@ -1201,14 +1204,14 @@ protected:
           static_cast<size_t>(_s) * static_cast<size_t>(_nodes_size), 
           static_cast<size_t>(_s) * static_cast<size_t>(new_nodes_size)) && 
           _verbose)
-          showUpdate("File truncation error\n");
+          Annoy_showUpdate("File truncation error\n");
     } else {
       _nodes = realloc(_nodes, _s * new_nodes_size);
       memset((char *) _nodes + (_nodes_size * _s) / sizeof(char), 0, (new_nodes_size - _nodes_size) * _s);
     }
     
     _nodes_size = new_nodes_size;
-    if (_verbose) showUpdate("Reallocating to %d nodes: old_address=%p, new_address=%p\n", new_nodes_size, old, _nodes);
+    if (_verbose) Annoy_showUpdate("Reallocating to %d nodes: old_address=%p, new_address=%p\n", new_nodes_size, old, _nodes);
   }
 
   void _allocate_size(S n, ThreadedBuildPolicy& threaded_build_policy) {
@@ -1290,7 +1293,7 @@ protected:
           bool side = D::side(m, n->v, _f, _random);
           children_indices[side].push_back(j);
         } else {
-          showUpdate("No node for index %d?\n", j);
+          Annoy_showUpdate("No node for index %d?\n", j);
         }
       }
 
@@ -1302,7 +1305,7 @@ protected:
     // If we didn't find a hyperplane, just randomize sides as a last option
     while (_split_imbalance(children_indices[0], children_indices[1]) > 0.99) {
       if (_verbose)
-        showUpdate("\tNo hyperplane found (left has %ld children, right has %ld children)\n",
+        Annoy_showUpdate("\tNo hyperplane found (left has %ld children, right has %ld children)\n",
           children_indices[0].size(), children_indices[1].size());
 
       children_indices[0].clear();
@@ -1485,6 +1488,8 @@ public:
   }
 };
 #endif
+
+}
 
 #endif
 // vim: tabstop=2 shiftwidth=2

--- a/src/annoyluamodule.cc
+++ b/src/annoyluamodule.cc
@@ -28,6 +28,8 @@
 #define compat_rawlen lua_rawlen
 #endif
 
+using namespace Annoy;
+
 template<typename Distance>
 class LuaAnnoy {
 public:

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -54,6 +54,8 @@ typedef signed __int32    int32_t;
     #define PyInt_FromLong PyLong_FromLong 
 #endif
 
+using namespace Annoy;
+
 #ifdef ANNOYLIB_MULTITHREADED_BUILD
   typedef AnnoyIndexMultiThreadedBuildPolicy AnnoyIndexThreadedBuildPolicy;
 #else

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -24,9 +24,9 @@ typedef signed __int32    int32_t;
 #endif
 
 
-#if defined(USE_AVX512)
+#if defined(ANNOYLIB_USE_AVX512)
 #define AVX_INFO "Using 512-bit AVX instructions"
-#elif defined(USE_AVX128)
+#elif defined(ANNOYLIB_USE_AVX128)
 #define AVX_INFO "Using 128-bit AVX instructions"
 #else
 #define AVX_INFO "Not using AVX instructions"

--- a/src/kissrandom.h
+++ b/src/kissrandom.h
@@ -1,5 +1,5 @@
-#ifndef KISSRANDOM_H
-#define KISSRANDOM_H
+#ifndef ANNOY_KISSRANDOM_H
+#define ANNOY_KISSRANDOM_H
 
 #if defined(_MSC_VER) && _MSC_VER == 1500
 typedef unsigned __int32    uint32_t;
@@ -7,6 +7,8 @@ typedef unsigned __int64    uint64_t;
 #else
 #include <stdint.h>
 #endif
+
+namespace Annoy {
 
 // KISS = "keep it simple, stupid", but high quality random number generator
 // http://www0.cs.ucl.ac.uk/staff/d.jones/GoodPracticeRNG.pdf -> "Use a good RNG and build it into your code"
@@ -111,6 +113,8 @@ struct Kiss64Random {
     x = seed;
   }
 };
+
+}
 
 #endif
 // vim: tabstop=2 shiftwidth=2


### PR DESCRIPTION
This PR aims to make **Annoy** slightly more friendly to use inside other C++ libraries via CMake.

The first change is to add a `CMakeLists.txt` file that enables downstream projects to easily use **Annoy** with:

```
include(FetchContent)
FetchContent_Declare(
  Annoy 
  GIT_REPOSITORY https://github.com/LTLA/Annoy # replace with spotify/annoy
  GIT_TAG cmake # replace with tag name
)
FetchContent_MakeAvailable(Annoy)
target_link_libraries(mylib INTERFACE Annoy)
```

No need to vendor the files, they'll get pulled in during the build configuration of `mylib`. Usage in source files is then as simple as:

```cpp
#include "annoy/annoylib.h"

Annoy::AnnoyIndex< ... >; // etc, etc.
```

The CMake build configuration shifts the header files into an `include/annoy` subdirectory, so as to minimize conflicts with header files of the same name in other parts of the `mylib` project. Which brings me to the next point...

The second change is to add `Annoy::` namespaces to as many things as I could. Every function and class in `annoylib.h` and `kissrandom.h`. (I didn't have the courage to do so for `mman.h`; given that was mimicking a system header, I just left it alone.) The motivation is to avoid name clashes with other classes in a large project, e.g., `Base` is a particularly common name. If this PR is accepted, it would be a breaking change for anyone who is living at **Annoy**'s head. The quick-and-dirty workaround is simple; just add `using namespace Annoy;` somewhere in the source file, like I did in `annoymodule.cc`.

On a related note, the third change is to prefix as many of the newly `#define`d macros with `annoylib_` (function-like) or `ANNOYLIB_` (object-like). Again, this aims to avoid clobbering existing macros in a given compilation unit whenever somebody `#include`s the **Annoy** headers. It seems that most of these macros are only used internally, and the only observable breaking changes would be for downstream applications relying on the macro names. Not sure if that's a real problem or not.