### PR TITLE
Enable direct return of <distance, index> pairs.

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -1132,12 +1132,7 @@ public:
   vector<pair<T, S> > get_nns_by_item(S item, size_t n, int search_k, bool normalize = true) const {
     vector<pair<T, S> > output;
     const Node* m = _get(item);
-    _get_all_nns(m->v, n, search_k, output);
-    if (normalize) {
-      for (size_t i = 0; i < output.size(); i++) {
-        output[i].first = D::normalized_distance(output[i].first);
-      }
-    }
+    _get_all_nns(m->v, n, search_k, output, normalize);
     return output;
   }
 
@@ -1147,12 +1142,7 @@ public:
 
   vector<pair<T, S> > get_nns_by_vector(const T* w, size_t n, int search_k, bool normalize = true) const {
     vector<pair<T, S> > output;
-    _get_all_nns(w, n, search_k, output);
-    if (normalize) {
-      for (size_t i = 0; i < output.size(); i++) {
-        output[i].first = D::normalized_distance(output[i].first);
-      }
-    }
+    _get_all_nns(w, n, search_k, output, normalize);
     return output;
   }
 
@@ -1367,16 +1357,16 @@ protected:
 
   void _get_all_nns(const T* v, size_t n, int search_k, vector<S>* result, vector<T>* distances) const {
     vector<pair<T, S> > nns_dist;
-    _get_all_nns(v, n, search_k, nns_dist);
+    _get_all_nns(v, n, search_k, nns_dist, distances!=NULL);
     for (size_t i = 0; i < nns_dist.size(); i++) {
       if (distances)
-        distances->push_back(D::normalized_distance(nns_dist[i].first));
+        distances->push_back(nns_dist[i].first);
       result->push_back(nns_dist[i].second);
     }
     return;
   }
 
-  void _get_all_nns(const T* v, size_t n, int search_k, vector<pair<T, S> >& nns_dist) const {
+  void _get_all_nns(const T* v, size_t n, int search_k, vector<pair<T, S> >& nns_dist, bool normalize) const {
     Node* v_node = (Node *)alloca(_s);
     D::template zero_value<Node>(v_node);
     memcpy(v_node->v, v, sizeof(T) * _f);
@@ -1428,6 +1418,12 @@ protected:
     size_t p = n < m ? n : m; // Return this many items
     std::partial_sort(nns_dist.begin(), nns_dist.begin() + p, nns_dist.end());
     nns_dist.resize(p);
+
+    if (normalize) {
+      for (size_t i = 0; i < nns_dist.size(); i++) {
+        nns_dist[i].first = D::normalized_distance(nns_dist[i].first);
+      }
+    }
     return;
   }
 };


### PR DESCRIPTION
This just exposes the <distance, index> pairs for direct consumption by downstream applications. Otherwise I would have to do a round-trip through two intermediary vectors to get the vector of paired values that I wanted all along.

Impact on existing code should be minimal, the new methods are just overloads.