### PR TITLE
Add go mod init to setup instructions

### DIFF
--- a/README_GO.rst
+++ b/README_GO.rst
@@ -7,6 +7,7 @@ To install, you'll need Swig (tested with Swig 3.0.6 on OS X), and then just::
   mkdir -p $GOPATH/src/annoyindex
   cp src/annoygomodule_wrap.cxx src/annoyindex.go src/annoygomodule.h src/annoylib.h src/kissrandom.h test/annoy_test.go $GOPATH/src/annoyindex
   cd $GOPATH/src/annoyindex
+  go mod init annoyindex
   go get -t ...
   go test
   go build


### PR DESCRIPTION
The current setup instructions for Go worked for previous versions of the language, but stopped working in version 1.16 as a result of some [changes made to modules](https://go.dev/blog/go116-module-changes). When running the current instructions, I get the error below when running `go get -t ...` — this is fixed by running `go mod init` prior to the `go get` command, which I introduce with this change.

```
jackcook@mbp annoyindex % go get -t ...
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```