### PR TITLE
Replace one sprintf with snprintf to appease xcode 14

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -128,7 +128,7 @@ inline void set_error_from_errno(char **error, const char* msg) {
   annoylib_showUpdate("%s: %s (%d)\n", msg, strerror(errno), errno);
   if (error) {
     *error = (char *)malloc(256);  // TODO: win doesn't support snprintf
-    sprintf(*error, "%s: %s (%d)", msg, strerror(errno), errno);
+    snprintf(*error, 255, "%s: %s (%d)", msg, strerror(errno), errno);
   }
 }
 


### PR DESCRIPTION
This simple pull request replace a sole `sprintf` with `snprintf` which `xcode` under macOS 14 now deprecates.

No other changes.

/cc @erikbern 