### PR TITLE
Extended CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,33 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15...3.25 FATAL_ERROR)
+
 project(Annoy
-    DESCRIPTION "Approximate Nearest Neighbors Oh Yeah"
-    VERSION 1.17.0
-    LANGUAGES CXX
-)
+  DESCRIPTION "Approximate Nearest Neighbors Oh Yeah"
+  VERSION 1.17.1
+  LANGUAGES CXX)
 
 add_library(Annoy INTERFACE)
+add_library(Annoy::Annoy ALIAS Annoy)
 
-set(ANNOY_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include/annoy)
-file(MAKE_DIRECTORY ${ANNOY_INCLUDE_DIR})
 foreach (HEADER annoylib.h kissrandom.h mman.h)
-    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/src/${HEADER} DESTINATION ${ANNOY_INCLUDE_DIR})
-endforeach()
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/${HEADER}" "${CMAKE_CURRENT_BINARY_DIR}/include/annoy/${HEADER}" COPYONLY)
+endforeach ()
 
-target_include_directories(Annoy INTERFACE include/)
+target_include_directories(Annoy INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
 
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-    # Add Python set-up code here.
-endif()
+# Install
+include(GNUInstallDirs)
 
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(TARGETS Annoy
+  EXPORT AnnoyTargets)
+
+install(EXPORT AnnoyTargets
+  FILE AnnoyConfig.cmake
+  NAMESPACE Annoy::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/annoy)
+
+export(TARGETS Annoy NAMESPACE Annoy:: FILE AnnoyConfig.cmake)


### PR DESCRIPTION
Extended version of the current CMakeLists.txt:
- Add install target to install C++ headers and CMake config for find_package() support (also good for package managers such as vcpkg)
- Avoid writing to the source directory and copy headers to binary dir instead
- Use configure_file() instead of file(COPY) to avoid unnecessary copies on every CMake run
- Add namespaced target alias