### PR TITLE
fix(#626): do NOT apply -march-native on OSX intel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,14 +38,14 @@ with codecs.open('README.rst', encoding='utf-8') as fobj:
 # Various platform-dependent extras
 extra_compile_args = ['-D_CRT_SECURE_NO_WARNINGS', '-fpermissive']
 extra_link_args = []
-
-# Not all CPUs have march as a tuning parameter
-cputune = ['-march=native',]
 if platform.machine() == 'ppc64le':
     extra_compile_args += ['-mcpu=native',]
 
 if platform.machine() == 'x86_64':
-    extra_compile_args += cputune
+    # do not apply march on Intel Darwin
+    if platform.system() != 'Darwin':
+        # Not all CPUs have march as a tuning parameter
+        extra_compile_args += ['-march=native',]
 
 if os.name != 'nt':
     extra_compile_args += ['-O3', '-ffast-math', '-fno-associative-math']


### PR DESCRIPTION
Simply adds an extra guard when applying `-march=native`