### PR TITLE
cleaned Go support and added memory leak fix

### DIFF
--- a/README_GO.rst
+++ b/README_GO.rst
@@ -48,9 +48,10 @@ Go code example
        t = annoy.NewAnnoyIndexAngular(f)
        t.Load("test.ann")
        
-       var result []int
-       t.GetNnsByItem(0, 1000, -1, &result)
-       fmt.Printf("%v\n", result)
+       result := annoyindex.NewAnnoyVectorInt()
+       defer result.Free()
+       t.GetNnsByItem(0, 1000, -1, result)
+       fmt.Printf("%v\n", result.ToSlice())
   
   }
   

--- a/README_GO.rst
+++ b/README_GO.rst
@@ -69,6 +69,6 @@ A simple test is supplied in test/annoy_test.go.
 Discuss
 -------
 
-There might be some memory leaks. See [this issue](https://github.com/swig/swig/issues/2292).
+Memroy leak in the previous versions has been fixed thanks to https://github.com/swig/swig/issues/2292. (memory leak fix is implemented in https://github.com/Rikanishu/annoy-go)
 
 Go glue written by Taneli Leppä (@rosmo). You can contact me via email (see https://github.com/rosmo).

--- a/README_GO.rst
+++ b/README_GO.rst
@@ -1,16 +1,15 @@
 Install
 -------
 
-To install, you'll need Swig (tested with Swig 3.0.6 on OS X), and then just::
+To install, you'll need Swig (tested with Swig 4.2.1 on Ubuntu 24.04), and then just::
 
   swig -go -intgosize 64 -cgo -c++ src/annoygomodule.i
-  mkdir -p $GOPATH/src/annoyindex
-  cp src/annoygomodule_wrap.cxx src/annoyindex.go src/annoygomodule.h src/annoylib.h src/kissrandom.h test/annoy_test.go $GOPATH/src/annoyindex
-  cd $GOPATH/src/annoyindex
-  go mod init annoyindex
-  go get -t ...
+  mkdir -p $(go env GOPATH)/src/annoy
+  cp src/annoygomodule_wrap.cxx src/annoy.go src/annoygomodule.h src/annoylib.h src/kissrandom.h test/annoy_test.go $(go env GOPATH)/src/annoy
+  cd $(go env GOPATH)/src/annoy
+  go mod init github.com/spotify/annoy
+  go mod tidy
   go test
-  go build
 
 Background
 ----------
@@ -25,14 +24,15 @@ Go code example
   package main
   
   import (
-         "annoyindex"
          "fmt"
          "math/rand"
+
+         "github.com/spotify/annoy"
   )
   
   func main() {
        f := 40
-       t := annoyindex.NewAnnoyIndexAngular(f)
+       t := annoy.NewAnnoyIndexAngular(f)
        for i := 0; i < 1000; i++ {
        	 item := make([]float32, 0, f)
        	 for x:= 0; x < f; x++ {
@@ -43,9 +43,9 @@ Go code example
        t.Build(10)
        t.Save("test.ann")
   
-       annoyindex.DeleteAnnoyIndexAngular(t)
+       annoy.DeleteAnnoyIndexAngular(t)
        
-       t = annoyindex.NewAnnoyIndexAngular(f)
+       t = annoy.NewAnnoyIndexAngular(f)
        t.Load("test.ann")
        
        var result []int

--- a/src/annoygomodule.h
+++ b/src/annoygomodule.h
@@ -5,6 +5,73 @@ using namespace Annoy;
 
 namespace GoAnnoy {
 
+
+class AnnoyVectorFloat {
+    protected:
+        float *ptr;
+        int len;
+
+    public:
+      ~AnnoyVectorFloat() {
+        free(ptr);
+      };
+      float* ArrayPtr() {
+        return ptr;
+      };
+      int Len() {
+        return len;
+      };
+      float Get(int i) {
+        if (i >= len) {
+            return 0.0;
+        }
+        return ptr[i];
+      };
+      void fill_from_vector(vector<float>* v) {
+            if (ptr != NULL) {
+               free(ptr);
+            }
+            ptr = (float*) malloc(v->size() * sizeof(float));
+            for (int i = 0; i < v->size(); i++) {
+                ptr[i] = (float)(*v)[i];
+            }
+            len = v->size();
+      };
+};
+
+class AnnoyVectorInt {
+    protected:
+        int32_t *ptr;
+        int len;
+
+    public:
+      ~AnnoyVectorInt() {
+        free(ptr);
+      };
+      int32_t* ArrayPtr() {
+        return ptr;
+      };
+      int Len() {
+        return len;
+      };
+      int32_t Get(int i) {
+        if (i >= len) {
+            return 0.0;
+        }
+        return ptr[i];
+      };
+      void fill_from_vector(vector<int32_t>* v) {
+            if (ptr != NULL) {
+                free(ptr);
+            }
+            ptr = (int32_t*) malloc(v->size() * sizeof(int32_t));
+            for (int i = 0; i < v->size(); i++) {
+                ptr[i] = (int32_t)(*v)[i];
+            }
+            len = v->size();
+      };
+};
+
 class AnnoyIndex {
  protected:
   ::AnnoyIndexInterface<int32_t, float> *ptr;
@@ -39,17 +106,43 @@ class AnnoyIndex {
   float getDistance(int i, int j) {
     return ptr->get_distance(i, j);
   };
-  void getNnsByItem(int item, int n, int search_k, vector<int32_t>* result, vector<float>* distances) {
+  void getNnsByItem(int item, int n, int search_k, AnnoyVectorInt* out_result, AnnoyVectorFloat* out_distances) {
+    vector<int32_t>* result = new vector<int32_t>();
+    vector<float>* distances = new vector<float>();
+
     ptr->get_nns_by_item(item, n, search_k, result, distances);
+
+    out_result->fill_from_vector(result);
+    out_distances->fill_from_vector(distances);
+    delete result;
+    delete distances;
   };
-  void getNnsByVector(const float* w, int n, int search_k, vector<int32_t>* result, vector<float>* distances) {
+  void getNnsByVector(const float* w, int n, int search_k, AnnoyVectorInt* out_result, AnnoyVectorFloat* out_distances) {
+    vector<int32_t>* result = new vector<int32_t>();
+    vector<float>* distances = new vector<float>();
+
     ptr->get_nns_by_vector(w, n, search_k, result, distances);
+
+    out_result->fill_from_vector(result);
+    out_distances->fill_from_vector(distances);
+    delete result;
+    delete distances;
   };
-  void getNnsByItem(int item, int n, int search_k, vector<int32_t>* result) {
+  void getNnsByItem(int item, int n, int search_k, AnnoyVectorInt* out_result) {
+    vector<int32_t>* result = new vector<int32_t>();
+
     ptr->get_nns_by_item(item, n, search_k, result, NULL);
+
+    out_result->fill_from_vector(result);
+    delete result;
   };
-  void getNnsByVector(const float* w, int n, int search_k, vector<int32_t>* result) {
+  void getNnsByVector(const float* w, int n, int search_k, AnnoyVectorInt* out_result) {
+    vector<int32_t>* result = new vector<int32_t>();
+
     ptr->get_nns_by_vector(w, n, search_k, result, NULL);
+
+    out_result->fill_from_vector(result);
+    delete result;
   };
 
   int getNItems() {
@@ -58,9 +151,11 @@ class AnnoyIndex {
   void verbose(bool v) {
     ptr->verbose(v);
   };
-  void getItem(int item, vector<float> *v) {
-    v->resize(this->f);
-    ptr->get_item(item, &v->front());
+  void getItem(int item, AnnoyVectorFloat *v) {
+    vector<float>* r = new vector<float>();
+    r->resize(this->f);
+    ptr->get_item(item, &r->front());
+    v->fill_from_vector(r);
   };
   bool onDiskBuild(const char* filename) {
     return ptr->on_disk_build(filename);

--- a/src/annoygomodule.i
+++ b/src/annoygomodule.i
@@ -9,6 +9,7 @@ namespace Annoy {}
 
 // const float *
 %typemap(gotype) (const float *)  "[]float32"
+%typemap(gotype) (int32_t)  "int32"
 
 %typemap(in) (const float *)
 %{
@@ -19,57 +20,6 @@ namespace Annoy {}
        w.push_back(v[i]);
     }
     $1 = &w[0];
-%}
-
-// vector<int32_t> *
-%typemap(gotype) (vector<int32_t> *)  "*[]int"
-
-%typemap(in) (vector<int32_t> *)
-%{
-  $1 = new vector<int32_t>();
-%}
-
-%typemap(freearg) (vector<int32_t> *)
-%{
-  delete $1;
-%}
-
-%typemap(argout) (vector<int32_t> *)
-%{
-  {
-    $input->len = $1->size();
-    $input->cap = $1->size();
-    $input->array = malloc($input->len * sizeof(intgo));
-    for (int i = 0; i < $1->size(); i++) {
-        ((intgo *)$input->array)[i] = (intgo)(*$1)[i];
-    }
-  }
-%}
-
-
-// vector<float> *
-%typemap(gotype) (vector<float> *)  "*[]float32"
-
-%typemap(in) (vector<float> *)
-%{
-  $1 = new vector<float>();
-%}
-
-%typemap(freearg) (vector<float> *)
-%{
-  delete $1;
-%}
-
-%typemap(argout) (vector<float> *)
-%{
-  {
-    $input->len = $1->size();
-    $input->cap = $1->size();
-    $input->array = malloc($input->len * sizeof(float));
-    for (int i = 0; i < $1->size(); i++) {
-        ((float *)$input->array)[i] = (float)(*$1)[i];
-    }
-  }
 %}
 
 
@@ -86,6 +36,106 @@ namespace Annoy {}
   free($1);
 %}
 
+
+%ignore fill_from_vector;
+%rename(X_RawAnnoyVectorInt) AnnoyVectorInt;
+%rename(X_RawAnnoyVectorFloat) AnnoyVectorFloat;
+
+%insert(go_wrapper) %{
+
+type AnnoyVectorInt interface {
+  X_RawAnnoyVectorInt
+  ToSlice() []int32
+  Copy(in *[]int32)
+  InnerArray() []int32
+  Free()
+}
+
+func NewAnnoyVectorInt() AnnoyVectorInt {
+    vec := NewX_RawAnnoyVectorInt()
+    return vec.(SwigcptrX_RawAnnoyVectorInt)
+}
+
+func (p SwigcptrX_RawAnnoyVectorInt) ToSlice() []int32 {
+    var out []int32
+    p.Copy(&out)
+    return out
+}
+
+func (p SwigcptrX_RawAnnoyVectorInt) Copy(in *[]int32)  {
+    out := *in
+    inner := p.InnerArray()
+    if cap(out) >= len(inner) {
+        if len(out) != len(inner) {
+          out = out[:len(inner)]
+        }
+    } else {
+        out = make([]int32, len(inner))
+    }
+
+    copy(out, inner)
+    *in = out
+}
+
+func (p SwigcptrX_RawAnnoyVectorInt) Free() {
+    DeleteX_RawAnnoyVectorInt(p)
+}
+
+func (p SwigcptrX_RawAnnoyVectorInt) InnerArray() []int32 {
+	length := p.Len()
+    ptr := unsafe.Pointer(p.ArrayPtr())
+	return ((*[1 << 30]int32)(ptr))[:length:length]
+}
+
+%}
+
+%insert(go_wrapper) %{
+
+type AnnoyVectorFloat interface {
+  X_RawAnnoyVectorFloat
+  ToSlice() []float32
+  Copy(in *[]float32)
+  InnerArray() []float32
+  Free()
+}
+
+func NewAnnoyVectorFloat() AnnoyVectorFloat {
+    vec := NewX_RawAnnoyVectorFloat()
+    return vec.(SwigcptrX_RawAnnoyVectorFloat)
+}
+
+func (p SwigcptrX_RawAnnoyVectorFloat) ToSlice() []float32 {
+    var out []float32
+    p.Copy(&out)
+    return out
+}
+
+func (p SwigcptrX_RawAnnoyVectorFloat) Copy(in *[]float32)  {
+    out := *in
+    inner := p.InnerArray()
+    if cap(out) >= len(inner) {
+        if len(out) != len(inner) {
+          out = out[:len(inner)]
+        }
+    } else {
+        out = make([]float32, len(inner))
+    }
+
+    copy(out, inner)
+    *in = out
+}
+
+func (p SwigcptrX_RawAnnoyVectorFloat) Free() {
+    DeleteX_RawAnnoyVectorFloat(p)
+}
+
+func (p SwigcptrX_RawAnnoyVectorFloat) InnerArray() []float32 {
+    length := p.Len()
+    ptr := unsafe.Pointer(p.ArrayPtr())
+    return ((*[1 << 30]float32)(ptr))[:length:length]
+}
+
+%}
 
 /* Let's just grab the original header file here */
 %include "annoygomodule.h"

--- a/src/annoygomodule.i
+++ b/src/annoygomodule.i
@@ -1,4 +1,4 @@
-%module annoyindex
+%module annoy
 
 namespace Annoy {}
 

--- a/test/annoy_test.go
+++ b/test/annoy_test.go
@@ -12,247 +12,247 @@
 # the License.
 */
 
-package annoyindex_test
+package annoy_test
 
 import (
-       "annoyindex"
-       "os"
-       "testing"
-       "math"
-       "math/rand"
-       "github.com/stretchr/testify/assert"
-       "github.com/stretchr/testify/suite"
+	"math"
+	"math/rand"
+	"os"
+	"testing"
+
+	"github.com/spotify/annoy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 type AnnoyTestSuite struct {
-    suite.Suite
+	suite.Suite
 }
 
 func Round(f float64) float64 {
-    return math.Floor(f + 0.5)
+	return math.Floor(f + 0.5)
 }
 
-func RoundPlus(f float64, places int) (float64) {
-     shift := math.Pow(10, float64(places))
-     return Round(f * shift) / shift
+func RoundPlus(f float64, places int) float64 {
+	shift := math.Pow(10, float64(places))
+	return Round(f*shift) / shift
 }
 
 func (suite *AnnoyTestSuite) SetupTest() {
 }
 
 func (suite *AnnoyTestSuite) TestFileHandling() {
-     index := annoyindex.NewAnnoyIndexAngular(3)
-     index.AddItem(0, []float32{0, 0, 1})
-     index.AddItem(1, []float32{0, 1, 0})
-     index.AddItem(2, []float32{1, 0, 0})
-     index.Build(10)
+	index := annoy.NewAnnoyIndexAngular(3)
+	index.AddItem(0, []float32{0, 0, 1})
+	index.AddItem(1, []float32{0, 1, 0})
+	index.AddItem(2, []float32{1, 0, 0})
+	index.Build(10)
 
-     index.Save("go_test.ann")
+	index.Save("go_test.ann")
 
-     info, err := os.Stat("go_test.ann")
-     if err != nil {
-        assert.Fail(suite.T(), "Failed to create file, file not found")
-     }
-     if info.Size() == 0 {
-        assert.Fail(suite.T(), "Failed to create file, file size zero")
-     }
+	info, err := os.Stat("go_test.ann")
+	if err != nil {
+		assert.Fail(suite.T(), "Failed to create file, file not found")
+	}
+	if info.Size() == 0 {
+		assert.Fail(suite.T(), "Failed to create file, file size zero")
+	}
 
-     annoyindex.DeleteAnnoyIndexAngular(index)
+	annoy.DeleteAnnoyIndexAngular(index)
 
-     index = annoyindex.NewAnnoyIndexAngular(3)
-     if ret := index.Load("go_test.ann"); ret == false {
-        assert.Fail(suite.T(), "Failed to load file")
-     }
+	index = annoy.NewAnnoyIndexAngular(3)
+	if ret := index.Load("go_test.ann"); ret == false {
+		assert.Fail(suite.T(), "Failed to load file")
+	}
 
-     os.Remove("go_test.ann")
-     index.Save("go_test2.ann", false)
+	os.Remove("go_test.ann")
+	index.Save("go_test2.ann", false)
 
-     info, err = os.Stat("go_test2.ann")
-     if err != nil {
-        assert.Fail(suite.T(), "Failed to create file without prefault, file not found")
-     }
-     if info.Size() == 0 {
-        assert.Fail(suite.T(), "Failed to create file without prefault, file size zero")
-     }
+	info, err = os.Stat("go_test2.ann")
+	if err != nil {
+		assert.Fail(suite.T(), "Failed to create file without prefault, file not found")
+	}
+	if info.Size() == 0 {
+		assert.Fail(suite.T(), "Failed to create file without prefault, file size zero")
+	}
 
-     annoyindex.DeleteAnnoyIndexAngular(index)
+	annoy.DeleteAnnoyIndexAngular(index)
 
-     index = annoyindex.NewAnnoyIndexAngular(3)
-     if ret := index.Load("go_test2.ann", false); ret == false {
-        assert.Fail(suite.T(), "Failed to load file without prefault")
-     }
+	index = annoy.NewAnnoyIndexAngular(3)
+	if ret := index.Load("go_test2.ann", false); ret == false {
+		assert.Fail(suite.T(), "Failed to load file without prefault")
+	}
 
-     os.Remove("go_test2.ann")
-     index.Save("go_test3.ann", true)
+	os.Remove("go_test2.ann")
+	index.Save("go_test3.ann", true)
 
-     info, err = os.Stat("go_test3.ann")
-     if err != nil {
-        assert.Fail(suite.T(), "Failed to create file allowing prefault, file not found")
-     }
-     if info.Size() == 0 {
-        assert.Fail(suite.T(), "Failed to create file allowing prefault, file size zero")
-     }
+	info, err = os.Stat("go_test3.ann")
+	if err != nil {
+		assert.Fail(suite.T(), "Failed to create file allowing prefault, file not found")
+	}
+	if info.Size() == 0 {
+		assert.Fail(suite.T(), "Failed to create file allowing prefault, file size zero")
+	}
 
-     annoyindex.DeleteAnnoyIndexAngular(index)
+	annoy.DeleteAnnoyIndexAngular(index)
 
-     index = annoyindex.NewAnnoyIndexAngular(3)
-     if ret := index.Load("go_test3.ann", true); ret == false {
-        assert.Fail(suite.T(), "Failed to load file allowing prefault")
-     }
-     annoyindex.DeleteAnnoyIndexAngular(index)
+	index = annoy.NewAnnoyIndexAngular(3)
+	if ret := index.Load("go_test3.ann", true); ret == false {
+		assert.Fail(suite.T(), "Failed to load file allowing prefault")
+	}
+	annoy.DeleteAnnoyIndexAngular(index)
 
-     os.Remove("go_test3.ann")
+	os.Remove("go_test3.ann")
 }
 
 func (suite *AnnoyTestSuite) TestOnDiskBuild() {
-     index := annoyindex.NewAnnoyIndexAngular(3)
-     index.OnDiskBuild("go_test.ann");
+	index := annoy.NewAnnoyIndexAngular(3)
+	index.OnDiskBuild("go_test.ann")
 
-     info, err := os.Stat("go_test.ann")
-     if err != nil {
-        assert.Fail(suite.T(), "Failed to create file, file not found")
-     }
-     if info.Size() == 0 {
-        assert.Fail(suite.T(), "Failed to create file, file size zero")
-     }
+	info, err := os.Stat("go_test.ann")
+	if err != nil {
+		assert.Fail(suite.T(), "Failed to create file, file not found")
+	}
+	if info.Size() == 0 {
+		assert.Fail(suite.T(), "Failed to create file, file size zero")
+	}
 
-     index.AddItem(0, []float32{0, 0, 1})
-     index.AddItem(1, []float32{0, 1, 0})
-     index.AddItem(2, []float32{1, 0, 0})
-     index.Build(10)
+	index.AddItem(0, []float32{0, 0, 1})
+	index.AddItem(1, []float32{0, 1, 0})
+	index.AddItem(2, []float32{1, 0, 0})
+	index.Build(10)
 
-     index.Unload();
-     index.Load("go_test.ann");
+	index.Unload()
+	index.Load("go_test.ann")
 
-     var result []int
-     index.GetNnsByVector([]float32{3, 2, 1}, 3, -1, &result)
-     assert.Equal(suite.T(), []int{2, 1, 0}, result)
+	var result []int
+	index.GetNnsByVector([]float32{3, 2, 1}, 3, -1, &result)
+	assert.Equal(suite.T(), []int{2, 1, 0}, result)
 
-     index.GetNnsByVector([]float32{1, 2, 3}, 3, -1, &result)
-     assert.Equal(suite.T(), []int{0, 1, 2}, result)
+	index.GetNnsByVector([]float32{1, 2, 3}, 3, -1, &result)
+	assert.Equal(suite.T(), []int{0, 1, 2}, result)
 
-     index.GetNnsByVector([]float32{2, 0, 1}, 3, -1, &result)
-     assert.Equal(suite.T(), []int{2, 0, 1}, result)
+	index.GetNnsByVector([]float32{2, 0, 1}, 3, -1, &result)
+	assert.Equal(suite.T(), []int{2, 0, 1}, result)
 
-     annoyindex.DeleteAnnoyIndexAngular(index)
+	annoy.DeleteAnnoyIndexAngular(index)
 
-     os.Remove("go_test.ann")
+	os.Remove("go_test.ann")
 }
 
 func (suite *AnnoyTestSuite) TestGetNnsByVector() {
-     index := annoyindex.NewAnnoyIndexAngular(3)
-     index.AddItem(0, []float32{0, 0, 1})
-     index.AddItem(1, []float32{0, 1, 0})
-     index.AddItem(2, []float32{1, 0, 0})
-     index.Build(10)
+	index := annoy.NewAnnoyIndexAngular(3)
+	index.AddItem(0, []float32{0, 0, 1})
+	index.AddItem(1, []float32{0, 1, 0})
+	index.AddItem(2, []float32{1, 0, 0})
+	index.Build(10)
 
-     var result []int
-     index.GetNnsByVector([]float32{3, 2, 1}, 3, -1, &result)
-     assert.Equal(suite.T(), []int{2, 1, 0}, result)
+	var result []int
+	index.GetNnsByVector([]float32{3, 2, 1}, 3, -1, &result)
+	assert.Equal(suite.T(), []int{2, 1, 0}, result)
 
-     index.GetNnsByVector([]float32{1, 2, 3}, 3, -1, &result)
-     assert.Equal(suite.T(), []int{0, 1, 2}, result)
+	index.GetNnsByVector([]float32{1, 2, 3}, 3, -1, &result)
+	assert.Equal(suite.T(), []int{0, 1, 2}, result)
 
-     index.GetNnsByVector([]float32{2, 0, 1}, 3, -1, &result)
-     assert.Equal(suite.T(), []int{2, 0, 1}, result)
+	index.GetNnsByVector([]float32{2, 0, 1}, 3, -1, &result)
+	assert.Equal(suite.T(), []int{2, 0, 1}, result)
 
-     annoyindex.DeleteAnnoyIndexAngular(index)
+	annoy.DeleteAnnoyIndexAngular(index)
 }
 
 func (suite *AnnoyTestSuite) TestGetNnsByItem() {
-     index := annoyindex.NewAnnoyIndexAngular(3)
-     index.AddItem(0, []float32{2, 1, 0})
-     index.AddItem(1, []float32{1, 2, 0})
-     index.AddItem(2, []float32{0, 0, 1})
-     index.Build(10)
+	index := annoy.NewAnnoyIndexAngular(3)
+	index.AddItem(0, []float32{2, 1, 0})
+	index.AddItem(1, []float32{1, 2, 0})
+	index.AddItem(2, []float32{0, 0, 1})
+	index.Build(10)
 
-     var result []int
-     index.GetNnsByItem(0, 3, -1, &result)
-     assert.Equal(suite.T(), []int{0, 1, 2}, result)
+	var result []int
+	index.GetNnsByItem(0, 3, -1, &result)
+	assert.Equal(suite.T(), []int{0, 1, 2}, result)
 
-     index.GetNnsByItem(1, 3, -1, &result)
-     assert.Equal(suite.T(), []int{1, 0, 2}, result)
+	index.GetNnsByItem(1, 3, -1, &result)
+	assert.Equal(suite.T(), []int{1, 0, 2}, result)
 
-     annoyindex.DeleteAnnoyIndexAngular(index)
+	annoy.DeleteAnnoyIndexAngular(index)
 }
 
 func (suite *AnnoyTestSuite) TestGetItem() {
-     index := annoyindex.NewAnnoyIndexAngular(3)
-     index.AddItem(0, []float32{2, 1, 0})
-     index.AddItem(1, []float32{1, 2, 0})
-     index.AddItem(2, []float32{0, 0, 1})
-     index.Build(10)
+	index := annoy.NewAnnoyIndexAngular(3)
+	index.AddItem(0, []float32{2, 1, 0})
+	index.AddItem(1, []float32{1, 2, 0})
+	index.AddItem(2, []float32{0, 0, 1})
+	index.Build(10)
 
-     var result []float32
+	var result []float32
 
-     index.GetItem(0, &result)
-     assert.Equal(suite.T(), []float32{2, 1, 0}, result)
+	index.GetItem(0, &result)
+	assert.Equal(suite.T(), []float32{2, 1, 0}, result)
 
-     index.GetItem(1, &result)
-     assert.Equal(suite.T(), []float32{1, 2, 0}, result)
+	index.GetItem(1, &result)
+	assert.Equal(suite.T(), []float32{1, 2, 0}, result)
 
-     index.GetItem(2, &result)
-     assert.Equal(suite.T(), []float32{0, 0, 1}, result)
+	index.GetItem(2, &result)
+	assert.Equal(suite.T(), []float32{0, 0, 1}, result)
 
-     annoyindex.DeleteAnnoyIndexAngular(index)
+	annoy.DeleteAnnoyIndexAngular(index)
 }
 
-
 func (suite *AnnoyTestSuite) TestGetDistance() {
-     index := annoyindex.NewAnnoyIndexAngular(2)
-     index.AddItem(0, []float32{0, 1})
-     index.AddItem(1, []float32{1, 1})
-     index.Build(10)
+	index := annoy.NewAnnoyIndexAngular(2)
+	index.AddItem(0, []float32{0, 1})
+	index.AddItem(1, []float32{1, 1})
+	index.Build(10)
 
-     assert.Equal(suite.T(), RoundPlus(math.Pow(2 * (1.0 - math.Pow(2, -0.5)), 0.5), 3), RoundPlus(float64(index.GetDistance(0, 1)), 3))
+	assert.Equal(suite.T(), RoundPlus(math.Pow(2*(1.0-math.Pow(2, -0.5)), 0.5), 3), RoundPlus(float64(index.GetDistance(0, 1)), 3))
 
-     annoyindex.DeleteAnnoyIndexAngular(index)
+	annoy.DeleteAnnoyIndexAngular(index)
 }
 
 func (suite *AnnoyTestSuite) TestGetDotProductDistance() {
-    index := annoyindex.NewAnnoyIndexDotProduct(2)
-    index.AddItem(0, []float32{0, 1})
-    index.AddItem(1, []float32{1, 1})
-    index.Build(10)
+	index := annoy.NewAnnoyIndexDotProduct(2)
+	index.AddItem(0, []float32{0, 1})
+	index.AddItem(1, []float32{1, 1})
+	index.Build(10)
 
-    assert.True(suite.T(),
-        math.Abs(1.0-float64(index.GetDistance(0, 1))) < 0.00001)
+	assert.True(suite.T(),
+		math.Abs(1.0-float64(index.GetDistance(0, 1))) < 0.00001)
 
-    annoyindex.DeleteAnnoyIndexDotProduct(index)
+	annoy.DeleteAnnoyIndexDotProduct(index)
 }
 
 func (suite *AnnoyTestSuite) TestLargeEuclideanIndex() {
-     index := annoyindex.NewAnnoyIndexEuclidean(10)
+	index := annoy.NewAnnoyIndexEuclidean(10)
 
-     for j := 0; j < 10000; j += 2 {
-         p := make([]float32, 0, 10)
-         for i := 0; i < 10; i++ {
-	     p = append(p, rand.Float32())
-	 }
-	 x := make([]float32, 0, 10)
-	 for i := 0; i < 10; i++ {
-	     x = append(x, 1 + p[i] + rand.Float32() * 1e-2)
-	 }
-	 y := make([]float32, 0, 10)
-	 for i := 0; i < 10; i++ {
-	     y = append(y, 1 + p[i] + rand.Float32() * 1e-2)
-	 }
-	 index.AddItem(j, x)
-	 index.AddItem(j + 1, y)
-     }
-     index.Build(10)
-     for j := 0; j < 10000; j += 2 {
-         var result []int
-	 index.GetNnsByItem(j, 2, -1, &result)
+	for j := 0; j < 10000; j += 2 {
+		p := make([]float32, 0, 10)
+		for i := 0; i < 10; i++ {
+			p = append(p, rand.Float32())
+		}
+		x := make([]float32, 0, 10)
+		for i := 0; i < 10; i++ {
+			x = append(x, 1+p[i]+rand.Float32()*1e-2)
+		}
+		y := make([]float32, 0, 10)
+		for i := 0; i < 10; i++ {
+			y = append(y, 1+p[i]+rand.Float32()*1e-2)
+		}
+		index.AddItem(j, x)
+		index.AddItem(j+1, y)
+	}
+	index.Build(10)
+	for j := 0; j < 10000; j += 2 {
+		var result []int
+		index.GetNnsByItem(j, 2, -1, &result)
 
-         assert.Equal(suite.T(), result, []int{j, j + 1})
+		assert.Equal(suite.T(), result, []int{j, j + 1})
 
-	 index.GetNnsByItem(j + 1, 2, -1, &result)
-	 assert.Equal(suite.T(), result, []int{j + 1, j})
-     }
-     annoyindex.DeleteAnnoyIndexEuclidean(index)
+		index.GetNnsByItem(j+1, 2, -1, &result)
+		assert.Equal(suite.T(), result, []int{j + 1, j})
+	}
+	annoy.DeleteAnnoyIndexEuclidean(index)
 }
 
 func TestAnnoyTestSuite(t *testing.T) {
-    suite.Run(t, new(AnnoyTestSuite))
+	suite.Run(t, new(AnnoyTestSuite))
 }


### PR DESCRIPTION
added the memory leak fix from [annoy-go](https://github.com/Rikanishu/annoy-go) implementation.
changed package name of experimental support of annoy for Go (changed from `annoyindex` to `github.com/spotify/annoy`) and reformatted tests.
it's a slightly more stable and cleaner version of the previous version.