### PR TITLE
Minor fixes to resolve some compilation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-20.04", "macos-latest", "windows-latest"]
-        signed: [true, false]
+        unsigned: [true, false]
 
     steps:
       - uses: actions/checkout@v3 # Pull the repository
@@ -20,10 +20,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Use unsigned
-        if: ${{ !matrix.signed }}
+      - name: Use unsigned indices
+        if: ${{ !matrix.unsigned }}
         run: |
-          cat src/annoymodule.cc | sed "s/int32_t Index_t/uint32_t Index_t/" | sed "s/ITEMF \"i\"/ITEMF \"I\"/" > .tmp
+          cat src/annoymodule.cc | sed "s/.*\(#define ANNOYLIB_UNSIGNED_INDEX\)/\1/" > .tmp
+          cmp .tmp src/annoymodule.cc && exit 1 # ensure a change was actually made.
           mv .tmp src/annoymodule.cc
 
       - run: pip install .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Use unsigned indices
-        if: ${{ !matrix.unsigned }}
+        if: ${{ matrix.unsigned }}
         run: |
           cat src/annoymodule.cc | sed "s/.*\(#define ANNOYLIB_UNSIGNED_INDEX\)/\1/" > .tmp
           cmp .tmp src/annoymodule.cc && exit 1 # ensure a change was actually made.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: Annoy
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: Annoy
 
 on:
   push:
-    branches:
-      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,20 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-20.04", "macos-latest", "windows-latest"]
+        signed: [true, false]
 
     steps:
       - uses: actions/checkout@v3 # Pull the repository
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Use unsigned
+        if: ${{ !matrix.signed }}
+        run: |
+          cat src/annoymodule.cc | sed "s/int32_t Index_t/uint32_t Index_t/" | sed "s/ITEMF \"i\"/ITEMF \"I\"/" > .tmp
+          mv .tmp src/annoymodule.cc
+
       - run: pip install .
       - run: pip install h5py numpy pytest
       - run: pytest -v

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ if platform.machine() == 'x86_64':
         extra_compile_args += ['-march=native',]
 
 if os.name != 'nt':
-    extra_compile_args += ['-O3', '-ffast-math', '-fno-associative-math']
+    extra_compile_args += ['-O3', '-ffast-math', '-fno-associative-math', '-Wall', '-Wpedantic', '-Wextra']
 
 # Add multithreaded build flag for all platforms using Python 3 and
 # for non-Windows Python 2 platforms

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ if platform.machine() == 'x86_64':
         extra_compile_args += ['-march=native',]
 
 if os.name != 'nt':
-    extra_compile_args += ['-O3', '-ffast-math', '-fno-associative-math', '-Wall', '-Wpedantic', '-Wextra']
+    extra_compile_args += ['-O3', '-ffast-math', '-fno-associative-math']
+    extra_compile_args += ['-Wall', '-Wpedantic', '-Wextra']
 
 # Add multithreaded build flag for all platforms using Python 3 and
 # for non-Windows Python 2 platforms

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -1531,6 +1531,7 @@ class AnnoyIndexSingleThreadedBuildPolicy {
 public:
   template<typename S, typename T, typename D, typename Random>
   static void build(AnnoyIndex<S, T, D, Random, AnnoyIndexSingleThreadedBuildPolicy>* annoy, int q, int n_threads) {
+    (void)n_threads; // silence unused variable warnings.
     AnnoyIndexSingleThreadedBuildPolicy threaded_build_policy;
     annoy->thread_build(q, 0, threaded_build_policy);
   }

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -1227,7 +1227,7 @@ public:
     for (S x = _n_nodes; x > 0; x--) { // S may be unsigned, so don't use >= 0 to terminate
       S i = x - 1;
       S k = _get(i)->n_descendants;
-      if (m == static_cast<S>(-1) || k == m) { // first expression is still valid if S is unsigned, as m would be the largest possible number of descendants
+      if (m == static_cast<S>(-1) || k == m) { // first condition is still valid if S is unsigned, as m would be the largest possible number of descendants
         _roots.push_back(i);
         m = k;
       } else {

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -1224,9 +1224,10 @@ public:
     // Find the roots by scanning the end of the file and taking the nodes with most descendants
     _roots.clear();
     S m = -1;
-    for (S i = _n_nodes - 1; i >= 0; i--) {
+    for (S x = _n_nodes; x > 0; x--) { // S may be unsigned, so don't use >= 0 to terminate
+      S i = x - 1;
       S k = _get(i)->n_descendants;
-      if (m == -1 || k == m) {
+      if (m == static_cast<S>(-1) || k == m) { // first expression is still valid if S is unsigned, as m would be the largest possible number of descendants
         _roots.push_back(i);
         m = k;
       } else {
@@ -1505,7 +1506,7 @@ protected:
     // To avoid calculating distance multiple times for any items, sort by id
     std::sort(nns.begin(), nns.end());
     vector<pair<T, S> > nns_dist;
-    S last = -1;
+    S last = -1; // Safe sentinel for unsigned S; all indices must be less than the max value of S, otherwise get_n_items() would overflow.
     for (size_t i = 0; i < nns.size(); i++) {
       S j = nns[i]; 
       if (j == last)

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -408,17 +408,29 @@ struct Base {
   static inline void preprocess(void* nodes, size_t _s, const S node_count, const int f) {
     // Override this in specific metric structs below if you need to do any pre-processing
     // on the entire set of nodes passed into this index.
+
+    (void)nodes; // silence unused variable warnings.
+    (void)_s;
+    (void)node_count;
+    (void)f;
   }
 
   template<typename T, typename S, typename Node>
   static inline void postprocess(void* nodes, size_t _s, const S node_count, const int f) {
     // Override this in specific metric structs below if you need to do any post-processing
     // on the entire set of nodes passed into this index.
+
+    (void)nodes; // silence unused variable warnings.
+    (void)_s;
+    (void)node_count;
+    (void)f;
   }
 
   template<typename Node>
   static inline void zero_value(Node* dest) {
     // Initialize any fields that require sane defaults within this node.
+
+    (void)dest; // silence unused variable warnings.
   }
 
   template<typename T, typename Node>
@@ -695,6 +707,7 @@ struct DotProduct : Angular {
 
   template<typename T, typename S, typename Node>
   static inline void postprocess(void* nodes, size_t _s, const S node_count, const int f) {
+    (void)f; // silence unused variable warnings.
     for (S i = 0; i < node_count; i++) {
       Node* node = get_node_ptr<S, Node>(nodes, _s, i);
       // When an index is built, we will remember it in index item nodes to compute distances differently
@@ -743,12 +756,14 @@ struct Hamming : Base {
   }
   template<typename S, typename T>
   static inline bool margin(const Node<S, T>* n, const T* y, int f) {
+    (void)f; // silence unused variable warnings.
     static const size_t n_bits = sizeof(T) * 8;
     T chunk = n->v[0] / n_bits;
     return (y[chunk] & (static_cast<T>(1) << (n_bits - 1 - (n->v[0] % n_bits)))) != 0;
   }
   template<typename S, typename T, typename Random>
   static inline bool side(const Node<S, T>* n, const T* y, int f, Random& random) {
+    (void)random; // silence unused variable warnings.
     return margin(n, y, f);
   }
   template<typename S, typename T, typename Random>
@@ -757,6 +772,7 @@ struct Hamming : Base {
   }
   template<typename S, typename T, typename Random>
   static inline void create_split(const vector<Node<S, T>*>& nodes, int f, size_t s, Random& random, Node<S, T>* n) {
+    (void)s; // silence unused variable warnings.
     size_t cur_size = 0;
     size_t i = 0;
     int dim = f * 8 * sizeof(T);
@@ -796,6 +812,8 @@ struct Hamming : Base {
   }
   template<typename S, typename T>
   static inline void init_node(Node<S, T>* n, int f) {
+    (void)n; // silence unused variable warnings.
+    (void)f;
   }
   static const char* name() {
     return "hamming";
@@ -864,6 +882,8 @@ struct Euclidean : Minkowski {
   }
   template<typename S, typename T>
   static inline void init_node(Node<S, T>* n, int f) {
+    (void)n; // silence unused variable warnings.
+    (void)f;
   }
   static const char* name() {
     return "euclidean";
@@ -895,6 +915,8 @@ struct Manhattan : Minkowski {
   }
   template<typename S, typename T>
   static inline void init_node(Node<S, T>* n, int f) {
+    (void)n; // silence unused variable warnings.
+    (void)f;
   }
   static const char* name() {
     return "manhattan";

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -65,10 +65,10 @@ using namespace Annoy;
 //#define ANNOYLIB_UNSIGNED_INDEX
 #ifdef ANNOYLIB_UNSIGNED_INDEX
 #define Index_t uint32_t
-#define ITEMF "I"
+#define INDEXF "I"
 #else
 #define Index_t int32_t
-#define ITEMF "i"
+#define INDEXF "i"
 #endif
 
 template class Annoy::AnnoyIndexInterface<Index_t, float>;
@@ -296,7 +296,9 @@ get_nns_to_python(const vector<Index_t>& result, const vector<float>& distances,
 
 bool check_constraints(py_annoy *self, Index_t item, bool building) {
 #ifdef ANNOYLIB_UNSIGNED_INDEX
-  if (item == static_cast<Index_t>(-1)) { // explicit -1 check is for tests with an unsigned Index_t.
+  // Special cased for unit tests, and besides, no item should have an index equal to the maximum,
+  // otherwise get_n_items() would not be representable.
+  if (item == static_cast<Index_t>(-1)) {
     PyErr_SetString(PyExc_IndexError, "Item index out of range");
     return false;
   }
@@ -322,7 +324,7 @@ py_an_get_nns_by_item(py_annoy *self, PyObject *args, PyObject *kwargs) {
     return NULL;
 
   static char const * kwlist[] = {"i", "n", "search_k", "include_distances", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, ITEMF ITEMF "|" ITEMF ITEMF, (char**)kwlist, &item, &n, &search_k, &include_distances))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, INDEXF INDEXF "|" INDEXF INDEXF, (char**)kwlist, &item, &n, &search_k, &include_distances))
     return NULL;
 
   if (!check_constraints(self, item, false)) {
@@ -379,7 +381,7 @@ py_an_get_nns_by_vector(py_annoy *self, PyObject *args, PyObject *kwargs) {
     return NULL;
 
   static char const * kwlist[] = {"vector", "n", "search_k", "include_distances", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O" ITEMF "|" ITEMF ITEMF, (char**)kwlist, &v, &n, &search_k, &include_distances))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O" INDEXF "|" INDEXF INDEXF, (char**)kwlist, &v, &n, &search_k, &include_distances))
     return NULL;
 
   vector<float> w(self->f);
@@ -403,7 +405,7 @@ py_an_get_item_vector(py_annoy *self, PyObject *args) {
   Index_t item;
   if (!self->ptr) 
     return NULL;
-  if (!PyArg_ParseTuple(args, ITEMF, &item))
+  if (!PyArg_ParseTuple(args, INDEXF, &item))
     return NULL;
 
   if (!check_constraints(self, item, false)) {
@@ -439,7 +441,7 @@ py_an_add_item(py_annoy *self, PyObject *args, PyObject* kwargs) {
   if (!self->ptr) 
     return NULL;
   static char const * kwlist[] = {"i", "vector", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, ITEMF "O", (char**)kwlist, &item, &v))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, INDEXF "O", (char**)kwlist, &item, &v))
     return NULL;
 
   if (!check_constraints(self, item, true)) {
@@ -534,7 +536,7 @@ py_an_get_distance(py_annoy *self, PyObject *args) {
   Index_t i, j;
   if (!self->ptr) 
     return NULL;
-  if (!PyArg_ParseTuple(args, ITEMF ITEMF, &i, &j))
+  if (!PyArg_ParseTuple(args, INDEXF INDEXF, &i, &j))
     return NULL;
 
   if (!check_constraints(self, i, false) || !check_constraints(self, j, false)) {

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -62,9 +62,14 @@ using namespace Annoy;
   typedef AnnoyIndexSingleThreadedBuildPolicy AnnoyIndexThreadedBuildPolicy;
 #endif
 
-#include <type_traits>
-typedef int32_t Index_t;
+//#define ANNOYLIB_UNSIGNED_INDEX
+#ifdef ANNOYLIB_UNSIGNED_INDEX
+#define Index_t uint32_t
+#define ITEMF "I"
+#else
+#define Index_t int32_t
 #define ITEMF "i"
+#endif
 
 template class Annoy::AnnoyIndexInterface<Index_t, float>;
 
@@ -178,6 +183,8 @@ py_an_new(PyTypeObject *type, PyObject *args, PyObject *kwargs) {
 
 static int 
 py_an_init(py_annoy *self, PyObject *args, PyObject *kwargs) {
+  (void)self; // silence unused variable warnings.
+
   // Seems to be needed for Python 3
   const char *metric = NULL;
   int f;
@@ -288,17 +295,17 @@ get_nns_to_python(const vector<Index_t>& result, const vector<float>& distances,
 
 
 bool check_constraints(py_annoy *self, Index_t item, bool building) {
-  if constexpr(std::is_signed<Index_t>::value) {
-      if (item < 0) {
-        PyErr_SetString(PyExc_IndexError, "Item index can not be negative");
-        return false;
-      }
-  } else {
-      if (item < 0 || item == static_cast<Index_t>(-1)) { // explicit -1 check is for tests with an unsigned Index_t.
-        PyErr_SetString(PyExc_IndexError, "Item index out of range");
-        return false;
-      }
+#ifdef ANNOYLIB_UNSIGNED_INDEX
+  if (item == static_cast<Index_t>(-1)) { // explicit -1 check is for tests with an unsigned Index_t.
+    PyErr_SetString(PyExc_IndexError, "Item index out of range");
+    return false;
   }
+#else
+  if (item < 0) {
+    PyErr_SetString(PyExc_IndexError, "Item index can not be negative");
+    return false;
+  }
+#endif
 
   if (!building && item >= self->ptr->get_n_items()) {
     PyErr_SetString(PyExc_IndexError, "Item index larger than the largest item index");

--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -62,31 +62,35 @@ using namespace Annoy;
   typedef AnnoyIndexSingleThreadedBuildPolicy AnnoyIndexThreadedBuildPolicy;
 #endif
 
-template class Annoy::AnnoyIndexInterface<int32_t, float>;
+#include <type_traits>
+typedef int32_t Index_t;
+#define ITEMF "i"
 
-class HammingWrapper : public AnnoyIndexInterface<int32_t, float> {
+template class Annoy::AnnoyIndexInterface<Index_t, float>;
+
+class HammingWrapper : public AnnoyIndexInterface<Index_t, float> {
   // Wrapper class for Hamming distance, using composition.
   // This translates binary (float) vectors into packed uint64_t vectors.
   // This is questionable from a performance point of view. Should reconsider this solution.
 private:
-  int32_t _f_external, _f_internal;
-  AnnoyIndex<int32_t, uint64_t, Hamming, Kiss64Random, AnnoyIndexThreadedBuildPolicy> _index;
+  Index_t _f_external, _f_internal;
+  AnnoyIndex<Index_t, uint64_t, Hamming, Kiss64Random, AnnoyIndexThreadedBuildPolicy> _index;
   void _pack(const float* src, uint64_t* dst) const {
-    for (int32_t i = 0; i < _f_internal; i++) {
+    for (Index_t i = 0; i < _f_internal; i++) {
       dst[i] = 0;
-      for (int32_t j = 0; j < 64 && i*64+j < _f_external; j++) {
+      for (Index_t j = 0; j < 64 && i*64+j < _f_external; j++) {
 	dst[i] |= (uint64_t)(src[i * 64 + j] > 0.5) << j;
       }
     }
   };
   void _unpack(const uint64_t* src, float* dst) const {
-    for (int32_t i = 0; i < _f_external; i++) {
+    for (Index_t i = 0; i < _f_external; i++) {
       dst[i] = (src[i / 64] >> (i % 64)) & 1;
     }
   };
 public:
   HammingWrapper(int f) : _f_external(f), _f_internal((f + 63) / 64), _index((f + 63) / 64) {};
-  bool add_item(int32_t item, const float* w, char**error) {
+  bool add_item(Index_t item, const float* w, char**error) {
     vector<uint64_t> w_internal(_f_internal, 0);
     _pack(w, &w_internal[0]);
     return _index.add_item(item, &w_internal[0], error);
@@ -96,8 +100,8 @@ public:
   bool save(const char* filename, bool prefault, char** error) { return _index.save(filename, prefault, error); };
   void unload() { _index.unload(); };
   bool load(const char* filename, bool prefault, char** error) { return _index.load(filename, prefault, error); };
-  float get_distance(int32_t i, int32_t j) const { return _index.get_distance(i, j); };
-  void get_nns_by_item(int32_t item, size_t n, int search_k, vector<int32_t>* result, vector<float>* distances) const {
+  float get_distance(Index_t i, Index_t j) const { return _index.get_distance(i, j); };
+  void get_nns_by_item(Index_t item, size_t n, int search_k, vector<Index_t>* result, vector<float>* distances) const {
     if (distances) {
       vector<uint64_t> distances_internal;
       _index.get_nns_by_item(item, n, search_k, result, &distances_internal);
@@ -106,7 +110,7 @@ public:
       _index.get_nns_by_item(item, n, search_k, result, NULL);
     }
   };
-  void get_nns_by_vector(const float* w, size_t n, int search_k, vector<int32_t>* result, vector<float>* distances) const {
+  void get_nns_by_vector(const float* w, size_t n, int search_k, vector<Index_t>* result, vector<float>* distances) const {
     vector<uint64_t> w_internal(_f_internal, 0);
     _pack(w, &w_internal[0]);
     if (distances) {
@@ -117,10 +121,10 @@ public:
       _index.get_nns_by_vector(&w_internal[0], n, search_k, result, NULL);
     }
   };
-  int32_t get_n_items() const { return _index.get_n_items(); };
-  int32_t get_n_trees() const { return _index.get_n_trees(); };
+  Index_t get_n_items() const { return _index.get_n_items(); };
+  Index_t get_n_trees() const { return _index.get_n_trees(); };
   void verbose(bool v) { _index.verbose(v); };
-  void get_item(int32_t item, float* v) const {
+  void get_item(Index_t item, float* v) const {
     vector<uint64_t> v_internal(_f_internal, 0);
     _index.get_item(item, &v_internal[0]);
     _unpack(&v_internal[0], v);
@@ -133,7 +137,7 @@ public:
 typedef struct {
   PyObject_HEAD
   int f;
-  AnnoyIndexInterface<int32_t, float>* ptr;
+  AnnoyIndexInterface<Index_t, float>* ptr;
 } py_annoy;
 
 
@@ -152,17 +156,17 @@ py_an_new(PyTypeObject *type, PyObject *args, PyObject *kwargs) {
     // This keeps coming up, see #368 etc
     PyErr_WarnEx(PyExc_FutureWarning, "The default argument for metric will be removed "
 		 "in future version of Annoy. Please pass metric='angular' explicitly.", 1);
-    self->ptr = new AnnoyIndex<int32_t, float, Angular, Kiss64Random, AnnoyIndexThreadedBuildPolicy>(self->f);
+    self->ptr = new AnnoyIndex<Index_t, float, Angular, Kiss64Random, AnnoyIndexThreadedBuildPolicy>(self->f);
   } else if (!strcmp(metric, "angular")) {
-   self->ptr = new AnnoyIndex<int32_t, float, Angular, Kiss64Random, AnnoyIndexThreadedBuildPolicy>(self->f);
+   self->ptr = new AnnoyIndex<Index_t, float, Angular, Kiss64Random, AnnoyIndexThreadedBuildPolicy>(self->f);
   } else if (!strcmp(metric, "euclidean")) {
-    self->ptr = new AnnoyIndex<int32_t, float, Euclidean, Kiss64Random, AnnoyIndexThreadedBuildPolicy>(self->f);
+    self->ptr = new AnnoyIndex<Index_t, float, Euclidean, Kiss64Random, AnnoyIndexThreadedBuildPolicy>(self->f);
   } else if (!strcmp(metric, "manhattan")) {
-    self->ptr = new AnnoyIndex<int32_t, float, Manhattan, Kiss64Random, AnnoyIndexThreadedBuildPolicy>(self->f);
+    self->ptr = new AnnoyIndex<Index_t, float, Manhattan, Kiss64Random, AnnoyIndexThreadedBuildPolicy>(self->f);
   } else if (!strcmp(metric, "hamming")) {
     self->ptr = new HammingWrapper(self->f);
   } else if (!strcmp(metric, "dot")) {
-    self->ptr = new AnnoyIndex<int32_t, float, DotProduct, Kiss64Random, AnnoyIndexThreadedBuildPolicy>(self->f);
+    self->ptr = new AnnoyIndex<Index_t, float, DotProduct, Kiss64Random, AnnoyIndexThreadedBuildPolicy>(self->f);
   } else {
     PyErr_SetString(PyExc_ValueError, "No such metric");
     return NULL;
@@ -237,7 +241,7 @@ py_an_save(py_annoy *self, PyObject *args, PyObject *kwargs) {
 
 
 PyObject*
-get_nns_to_python(const vector<int32_t>& result, const vector<float>& distances, int include_distances) {
+get_nns_to_python(const vector<Index_t>& result, const vector<float>& distances, int include_distances) {
   PyObject* l = NULL;
   PyObject* d = NULL;
   PyObject* t = NULL;
@@ -283,11 +287,20 @@ get_nns_to_python(const vector<int32_t>& result, const vector<float>& distances,
 }
 
 
-bool check_constraints(py_annoy *self, int32_t item, bool building) {
-  if (item < 0) {
-    PyErr_SetString(PyExc_IndexError, "Item index can not be negative");
-    return false;
-  } else if (!building && item >= self->ptr->get_n_items()) {
+bool check_constraints(py_annoy *self, Index_t item, bool building) {
+  if constexpr(std::is_signed<Index_t>::value) {
+      if (item < 0) {
+        PyErr_SetString(PyExc_IndexError, "Item index can not be negative");
+        return false;
+      }
+  } else {
+      if (item < 0 || item == static_cast<Index_t>(-1)) { // explicit -1 check is for tests with an unsigned Index_t.
+        PyErr_SetString(PyExc_IndexError, "Item index out of range");
+        return false;
+      }
+  }
+
+  if (!building && item >= self->ptr->get_n_items()) {
     PyErr_SetString(PyExc_IndexError, "Item index larger than the largest item index");
     return false;
   } else {
@@ -297,19 +310,19 @@ bool check_constraints(py_annoy *self, int32_t item, bool building) {
 
 static PyObject* 
 py_an_get_nns_by_item(py_annoy *self, PyObject *args, PyObject *kwargs) {
-  int32_t item, n, search_k=-1, include_distances=0;
+  Index_t item, n, search_k=-1, include_distances=0;
   if (!self->ptr) 
     return NULL;
 
   static char const * kwlist[] = {"i", "n", "search_k", "include_distances", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ii|ii", (char**)kwlist, &item, &n, &search_k, &include_distances))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, ITEMF ITEMF "|" ITEMF ITEMF, (char**)kwlist, &item, &n, &search_k, &include_distances))
     return NULL;
 
   if (!check_constraints(self, item, false)) {
     return NULL;
   }
 
-  vector<int32_t> result;
+  vector<Index_t> result;
   vector<float> distances;
 
   Py_BEGIN_ALLOW_THREADS;
@@ -354,12 +367,12 @@ convert_list_to_vector(PyObject* v, int f, vector<float>* w) {
 static PyObject* 
 py_an_get_nns_by_vector(py_annoy *self, PyObject *args, PyObject *kwargs) {
   PyObject* v;
-  int32_t n, search_k=-1, include_distances=0;
+  Index_t n, search_k=-1, include_distances=0;
   if (!self->ptr) 
     return NULL;
 
   static char const * kwlist[] = {"vector", "n", "search_k", "include_distances", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "Oi|ii", (char**)kwlist, &v, &n, &search_k, &include_distances))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O" ITEMF "|" ITEMF ITEMF, (char**)kwlist, &v, &n, &search_k, &include_distances))
     return NULL;
 
   vector<float> w(self->f);
@@ -367,7 +380,7 @@ py_an_get_nns_by_vector(py_annoy *self, PyObject *args, PyObject *kwargs) {
     return NULL;
   }
 
-  vector<int32_t> result;
+  vector<Index_t> result;
   vector<float> distances;
 
   Py_BEGIN_ALLOW_THREADS;
@@ -380,10 +393,10 @@ py_an_get_nns_by_vector(py_annoy *self, PyObject *args, PyObject *kwargs) {
 
 static PyObject* 
 py_an_get_item_vector(py_annoy *self, PyObject *args) {
-  int32_t item;
+  Index_t item;
   if (!self->ptr) 
     return NULL;
-  if (!PyArg_ParseTuple(args, "i", &item))
+  if (!PyArg_ParseTuple(args, ITEMF, &item))
     return NULL;
 
   if (!check_constraints(self, item, false)) {
@@ -415,11 +428,11 @@ py_an_get_item_vector(py_annoy *self, PyObject *args) {
 static PyObject* 
 py_an_add_item(py_annoy *self, PyObject *args, PyObject* kwargs) {
   PyObject* v;
-  int32_t item;
+  Index_t item;
   if (!self->ptr) 
     return NULL;
   static char const * kwlist[] = {"i", "vector", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "iO", (char**)kwlist, &item, &v))
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, ITEMF "O", (char**)kwlist, &item, &v))
     return NULL;
 
   if (!check_constraints(self, item, true)) {
@@ -511,10 +524,10 @@ py_an_unload(py_annoy *self) {
 
 static PyObject *
 py_an_get_distance(py_annoy *self, PyObject *args) {
-  int32_t i, j;
+  Index_t i, j;
   if (!self->ptr) 
     return NULL;
-  if (!PyArg_ParseTuple(args, "ii", &i, &j))
+  if (!PyArg_ParseTuple(args, ITEMF ITEMF, &i, &j))
     return NULL;
 
   if (!check_constraints(self, i, false) || !check_constraints(self, j, false)) {
@@ -531,7 +544,7 @@ py_an_get_n_items(py_annoy *self) {
   if (!self->ptr) 
     return NULL;
 
-  int32_t n = self->ptr->get_n_items();
+  Index_t n = self->ptr->get_n_items();
   return PyInt_FromLong(n);
 }
 
@@ -540,7 +553,7 @@ py_an_get_n_trees(py_annoy *self) {
   if (!self->ptr) 
     return NULL;
 
-  int32_t n = self->ptr->get_n_trees();
+  Index_t n = self->ptr->get_n_trees();
   return PyInt_FromLong(n);
 }
 

--- a/test/types_test.py
+++ b/test/types_test.py
@@ -59,8 +59,8 @@ def test_range_errors(n_points=1000, n_trees=10):
     i = AnnoyIndex(f, "euclidean")
     for j in range(n_points):
         i.add_item(j, [random.gauss(0, 1) for x in range(f)])
-    with pytest.raises(IndexError):
-        i.add_item(-1, [random.gauss(0, 1) for x in range(f)])
+#    with pytest.raises(IndexError):
+#        i.add_item(-1, [random.gauss(0, 1) for x in range(f)])
     i.build(n_trees)
     for bad_index in [-1000, -1, n_points, n_points + 1000]:
         with pytest.raises(IndexError):

--- a/test/types_test.py
+++ b/test/types_test.py
@@ -59,8 +59,8 @@ def test_range_errors(n_points=1000, n_trees=10):
     i = AnnoyIndex(f, "euclidean")
     for j in range(n_points):
         i.add_item(j, [random.gauss(0, 1) for x in range(f)])
-#    with pytest.raises(IndexError):
-#        i.add_item(-1, [random.gauss(0, 1) for x in range(f)])
+    with pytest.raises(IndexError):
+        i.add_item(-1, [random.gauss(0, 1) for x in range(f)])
     i.build(n_trees)
     for bad_index in [-1000, -1, n_points, n_points + 1000]:
         with pytest.raises(IndexError):


### PR DESCRIPTION
This PR aims to eliminate a bunch of GCC/clang compiler warnings.

Most of these relate to unused variables. I've used the `(void)variable` pattern to trick the compiler into silencing the warning. I could have used `[[maybe_unused]]` but decided against it as that would force everyone to use C++17. Alternatively, I could have just removed the variable name from the function signature, but the names seemed to be informative (e.g., for the `Base` methods) so I left them in.

Other warnings were related to signed/unsigned comparisons when the template type `S` is an unsigned integer. While I was working on this, I ended up also fixing a small bug in the `for` loop for unsigned `S`. I also extended the test suite to compile and test for unsigned indices. In hindsight this might be better off as a separate PR.

There are still some remaining warnings in `annoymodule.cc`, but those are related to interactions with the Python C API and I'm uncertain on how to fix them. At least the warnings in `annoylib.h` have all been resolved.

Also FYI, `ci.yml` actually doesn't test anywhere other than Linux, `{{ matrix.os }}` isn't actually used anywhere. So we just end up running triplicate CI on Linux while pretending that it's running on Windows and Mac.
