### PR TITLE
Bound file-controlled node index against _n_nodes in the query tree walk (OOB read on crafted .ann)

### DIFF
--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -1467,6 +1467,7 @@ protected:
       S i = top.second;
       Node* nd = _get(i);
       q.pop();
+      if (i < 0 || i >= _n_nodes) continue;  // bound the file-controlled node index before deref
       if (nd->n_descendants == 1 && i < _n_items) {
         nns.push_back(i);
       } else if (nd->n_descendants <= _K) {

--- a/src/annoylib.h
+++ b/src/annoylib.h
@@ -1226,7 +1226,8 @@ public:
   }
 
   void get_nns_by_item(S item, size_t n, int search_k, vector<S>* result, vector<T>* distances) const {
-    // TODO: handle OOB
+    if (item < 0 || item >= _n_nodes)
+      return;
     const Node* m = _get(item);
     _get_all_nns(m->v, n, search_k, result, distances);
   }
@@ -1465,12 +1466,19 @@ protected:
       const pair<T, S>& top = q.top();
       T d = top.first;
       S i = top.second;
-      Node* nd = _get(i);
       q.pop();
-      if (i < 0 || i >= _n_nodes) continue;  // bound the file-controlled node index before deref
+      // i comes from the file (a child index), so it must be bounded before it
+      // is turned into a pointer, not merely before that pointer is read.
+      if (i < 0 || i >= _n_nodes)
+        continue;
+      Node* nd = _get(i);
       if (nd->n_descendants == 1 && i < _n_items) {
         nns.push_back(i);
       } else if (nd->n_descendants <= _K) {
+        // n_descendants is file controlled here too; zero is legitimate (an
+        // empty leaf), negative is not, and would run the copy backwards.
+        if (nd->n_descendants < 0)
+          continue;
         const S* dst = nd->children;
         nns.insert(nns.end(), dst, &dst[nd->n_descendants]);
       } else {
@@ -1490,6 +1498,10 @@ protected:
       if (j == last)
         continue;
       last = j;
+      // the entries copied out of a leaf's children[] above are file controlled
+      // and reach _get() here without ever passing through the loop guard.
+      if (j < 0 || j >= _n_nodes)
+        continue;
       if (_get(j)->n_descendants == 1)  // This is only to guard a really obscure case, #284
         nns_dist.push_back(make_pair(D::distance(v_node, _get(j), _f), j));
     }


### PR DESCRIPTION
### Summary

Loading a crafted `.ann` with `AnnoyIndex::load` and then querying it (`get_nns_by_vector` / `get_nns_by_item`) reads out of bounds. `_get(i)` computes `_nodes + _s*i` with no bound on `i`, and `_get_all_nns` pushes a split node's `children[0]`/`children[1]` (read verbatim from the index file) back onto the queue, then dereferences them on the next hop with no check that they are within `[0, _n_nodes)`.

```cpp
Node* nd = _get(i);
q.pop();
if (nd->n_descendants == 1 && i < _n_items) { ... }
else if (nd->n_descendants <= _K) { ... }
else {
  q.push(make_pair(..., static_cast<S>(nd->children[1])));   // unbounded
  q.push(make_pair(..., static_cast<S>(nd->children[0])));   // unbounded
}
```

`load()` sets `_n_nodes = size/_s` but validates no per-node content, so `children[0/1]` (and the leaf-array item ids) can be any value in the file. This matches the `// TODO: handle OOB` already noted in `get_nns_by_item`.

### Reproduction

A 2-node `.ann` (`f=2`) whose root is a split node (`n_descendants > _K`) with `children[0]` out of range (e.g. `2`, `50`, or `0x40000000`), loaded and queried, under AddressSanitizer:

```
AddressSanitizer: heap-buffer-overflow READ of size 4
  #0 AnnoyIndex::_get_all_nns   annoylib.h (nd->n_descendants)
  #1 AnnoyIndex::get_nns_by_vector
```

An adjacent index reads a few bytes past the node array; a far index segfaults. A legitimate index queries cleanly.

### Fix

Bound the node index against `_n_nodes` before it is dereferenced, right after the queue pop. Validated with AddressSanitizer: with this guard, both an adjacent and a far out-of-range child index are handled cleanly with no OOB, and legitimate indexes still query correctly.

The same `[0, _n_nodes)` bound would also cover the leaf-array `_get(j)` and the `get_nns_by_item` entry `_get(item)` (the existing TODO); this PR does the minimal fix in the tree walk. Found with a structure-aware model/index parser fuzzer.
