### PR TITLE
ci: update deprecated GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
         os: ["ubuntu-20.04", "macos-latest", "windows-latest"]
 
     steps:
-      - uses: actions/checkout@v3 # Pull the repository
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4 # Pull the repository
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU (for Linux aarch64)
         if: runner.os == 'Linux'


### PR DESCRIPTION
Several workflow steps were pinned to Actions versions that GitHub has deprecated:

- `ci.yml`: `actions/checkout@v3` and `actions/setup-python@v4` both trigger the "Node.js 16 actions are deprecated" warning
- `publish.yml`: `actions/checkout@v2` is older still, based on the deprecated Node12 runtime

Bumped all three to their current major versions (checkout@v4, setup-python@v5), matching what `spotify/pedalboard` and `spotify/basic-pitch` already use in their own workflows. There are no functional changes to build logic, only to the Action versions.