### PR TITLE
fix: validate and raise ValueError for negative n in get_nns methods

### DIFF
--- a/src/annoymodule.cc
+++ b/src/annoymodule.cc
@@ -305,6 +305,11 @@ py_an_get_nns_by_item(py_annoy *self, PyObject *args, PyObject *kwargs) {
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ii|ii", (char**)kwlist, &item, &n, &search_k, &include_distances))
     return NULL;
 
+  if (n < 0) {
+    PyErr_SetString(PyExc_ValueError, "Number of neighbors cannot be negative.");
+    return NULL;
+  }
+
   if (!check_constraints(self, item, false)) {
     return NULL;
   }
@@ -361,6 +366,11 @@ py_an_get_nns_by_vector(py_annoy *self, PyObject *args, PyObject *kwargs) {
   static char const * kwlist[] = {"vector", "n", "search_k", "include_distances", NULL};
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "Oi|ii", (char**)kwlist, &v, &n, &search_k, &include_distances))
     return NULL;
+
+  if (n < 0) {
+    PyErr_SetString(PyExc_ValueError, "Number of neighbors cannot be negative.");
+    return NULL;
+  }
 
   vector<float> w(self->f);
   if (!convert_list_to_vector(v, self->f, &w)) {


### PR DESCRIPTION
Fixes #700. When passing a negative number for n (number of neighbors) to get_nns_by_item or get_nns_by_vector, the signed int32_t parses correctly but is cast to unsigned size_t inside get_nns_by_item in the C++ library. This causes it to become SIZE_MAX, leading to integer overflows in search_k and returning meaningless values or empty lists. This adds a clean check in the Python C-extension wrapper to raise a ValueError.